### PR TITLE
Fix: Timeout in seconds

### DIFF
--- a/lib/ci/index.js
+++ b/lib/ci/index.js
@@ -106,8 +106,8 @@ App.prototype = {
     var timeout = this.config.get('timeout')
     if (timeout){
       this.timeoutID = setTimeout(function(){
-        self.wrapUp(new Error('Timed out after ' + timeout + 'ms'))
-      }, timeout)
+        self.wrapUp(new Error('Timed out after ' + timeout + 's'))
+      }, timeout * 1000)
     }
     callback(null)
   },
@@ -146,7 +146,7 @@ App.prototype = {
     }
     setTimeout(callback, 500)
   },
-  
+
   stopHookRunners: function(){
     for (var runner in this.hookRunners){
       this.hookRunners[runner].stop()


### PR DESCRIPTION
Align the actual timeout with `testem ci -h`, which explains `-T` as
`timeout a browser after [sec] seconds`.