### PR TITLE
Prevent XMLHttpRequest in socket.io from being faked

### DIFF
--- a/public/testem/socket.io.js
+++ b/public/testem/socket.io.js
@@ -3370,6 +3370,7 @@ WS.prototype.check = function(){
 },{"../transport":13,"component-inherit":20,"debug":21,"engine.io-parser":24,"parseqs":32,"ws":34}],19:[function(_dereq_,module,exports){
 // browser shim for xmlhttprequest module
 var hasCORS = _dereq_('has-cors');
+var XMLHttpRequest = window.XMLHttpRequest;
 
 module.exports = function(opts) {
   var xdomain = opts.xdomain;


### PR DESCRIPTION
[Pretender](https://github.com/trek/pretender) (amongst others) swaps out window.XMLHttpRequest for a fake XHR object and undoes the fake at the end of each test. This obviously presents an issue for async tests where Testem might want to communicate over XHR midway through a test. It will encounter a fake XHR and things will stop being fun.

This patch keeps a reference to the original `window.XMLHttpRequest` as a variable within the lexical scope of the module that uses it.

See this [test case](https://github.com/jgwhite/testem-case) with ember-cli + pretender for a reproduction.

Run `ember test --server` in the repo to see Firefox get stuck in an reload loop. This patch should fix that.