### PR TITLE
Store reference to XMLHttpRequest

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -194,7 +194,8 @@ Server.prototype = {
 
     res.write(';(function(){')
     var files = [
-      require.resolve('socket.io/node_modules/socket.io-client/socket.io.js')
+      'save_window.js'
+      , require.resolve('socket.io/node_modules/socket.io-client/socket.io.js')
       , 'decycle.js'
       , 'jasmine_adapter.js'
       , 'jasmine2_adapter.js'

--- a/public/testem/save_window.js
+++ b/public/testem/save_window.js
@@ -1,0 +1,4 @@
+// Save references to window variables, which are likely to be mocked, but
+// required by testem
+
+var XMLHttpRequest = window.XMLHttpRequest;


### PR DESCRIPTION
Allows mocking of XMLHttpRequest, but does not patch the socket.io client directly.

Replaces https://github.com/airportyh/testem/pull/455