### PR TITLE
Fixed test path test on Windows

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -205,7 +205,7 @@ Server.prototype = {
       , 'testem_client.js'
     ]
     async.forEachSeries(files, function(file, done){
-      if (file.indexOf('/') === -1) {
+      if (file.indexOf(path.sep) === -1) {
         file = __dirname + '/../../public/testem/' + file
       }
       fs.readFile(file, function(err, data){


### PR DESCRIPTION
Windows uses \ instead of /