### PR TITLE
added pause functionality in TDD mode as well as specs for this functionality

### DIFF
--- a/lib/dev/index.js
+++ b/lib/dev/index.js
@@ -44,6 +44,7 @@ function App(config, finalizer){
 
   
   this.exited = false
+  this.paused = false
   this.finalizer = finalizer || process.exit
   this.fileWatcher = fireworm('./', {
     ignoreInitial: true
@@ -59,13 +60,7 @@ function App(config, finalizer){
     runner.unbind()
   })
 
-  this.view = new AppView({
-    app: this
-  })
-
-  this.view.on('ctrl-c', function(){
-    self.quit()
-  })
+  this.configureView()
 
   this.configure(function(){
     this.server = new Server(config)
@@ -133,6 +128,15 @@ App.prototype = {
       })
     })
   },
+  configureView: function() {
+    var self = this
+    this.view = new AppView({
+      app: this
+    })
+    this.view.on('ctrl-c', function(){
+      self.quit()
+    })
+  },
   configure: function(cb){
     var self = this
     var fileWatcher = self.fileWatcher
@@ -166,7 +170,7 @@ App.prototype = {
   },
   onFileChanged: function(filepath){
     log.info(filepath + ' changed ('+(this.disableFileWatch ? 'disabled' : 'enabled')+').')
-    if (this.disableFileWatch) return
+    if (this.disableFileWatch || this.paused) return
     var configFile = this.config.get('file')
     if ((configFile && filepath === Path.resolve(configFile)) ||
       (this.config.isCwdMode() && filepath === process.cwd())){
@@ -223,8 +227,15 @@ App.prototype = {
       log.info('Got keyboard Start Tests command')
       this.startTests()
     }
+    else if (chr === 'p') {
+      this.paused = !this.paused
+      this.view.renderBottom()
+    }
   },
   startTests: function(callback){
+    if (this.paused) {
+      return
+    }
     try{
       var view = this.view
       var runners = this.runners

--- a/lib/dev/ui/appview.js
+++ b/lib/dev/ui/appview.js
@@ -169,11 +169,14 @@ var AppView = module.exports = View.extend({
 
     var screen = this.get('screen')
     var cols = this.get('cols')
+    var pauseStatus = this.app.paused ? '; p to unpause (PAUSED)' : '; p to pause'
+
     var msg = (
       !this.get('atLeastOneRunner') ?
-      '[q to quit]' :
-      '[Press ENTER to run tests; q to quit]'
+      'q to quit' :
+      'Press ENTER to run tests; q to quit'
       )
+    msg = '[' + msg + pauseStatus + ']'
     screen
       .position(0, this.get('lines'))
       .write(pad(msg, cols - 1, ' ', 1))

--- a/tests/dev_tests.js
+++ b/tests/dev_tests.js
@@ -1,0 +1,41 @@
+var Backbone = require('backbone')
+var expect = require('chai').expect
+var Config = require('../lib/config')
+var DevApp = require('../lib/dev')
+var sinon = require('sinon')
+
+describe('Dev', function(){
+  var app, config, spy
+
+  beforeEach(function(){
+    config = new Config('dev')
+    sinon.stub(DevApp.prototype, "configureView")
+    sinon.stub(DevApp.prototype, "configure")
+    app = new DevApp(config, function(){})
+    app.view = {
+      clearErrorPopupMessage: function(){}
+    }
+  })
+
+  afterEach(function(){
+    DevApp.prototype.configureView.restore()
+    DevApp.prototype.configure.restore()
+  })
+
+  it("starts off not paused", function(){
+    expect(app.paused).to.be.false
+  })
+
+  it("doesn't run tests when reset and paused", function() {
+    app.paused = true
+    cb = sinon.spy()
+    app.startTests(cb)
+    expect(cb.called).to.be.false
+  })
+
+  it("runs tests when reset and not paused", function() {
+    cb = sinon.spy()
+    app.startTests(cb)
+    expect(cb.called).to.be.true
+  })
+})

--- a/tests/ui/appview_tests.js
+++ b/tests/ui/appview_tests.js
@@ -2,7 +2,7 @@ var AppView = require('../../lib/dev/ui/appview')
 var Backbone = require('backbone')
 var Config = require('../../lib/config')
 var screen = require('./fake_screen')
-var assert = require('chai').assert
+var expect = require('chai').expect
 
 describe('AppView', function(){
 
@@ -17,14 +17,24 @@ describe('AppView', function(){
       app: app,
       screen: screen
     })
-    screen.$setSize(10, 10)
+    screen.$setSize(80, 10)
+    appview.set({cols: 80, lines: 10})
   })
 
   it('initializes', function(){
     appview.renderTop()
     appview.renderMiddle()
     appview.renderBottom()
-
   })
 
+  it('starts off showing p to pause', function(){
+    appview.renderBottom()
+    expect(appview.get('screen').buffer.join('')).to.contain('p to pause')
+  })
+
+  it('says its paused when paused', function(){
+    app.paused = true
+    appview.renderBottom()
+    expect(appview.get('screen').buffer.join('')).to.contain('p to unpause')
+  })
 })


### PR DESCRIPTION
Now in TDD mode the person can type `p` and it will pause testem so that it doesn't run any tests (either due to file changes or when resetting testem). Pressing `p` again will unpause testem. This is useful if one is going to be changing lots of files and doesn't want to completely halt testem but doesn't want it running all the specs. 

 