### PR TITLE
find phantomjs by node module resolution

### DIFF
--- a/lib/browser_launcher.js
+++ b/lib/browser_launcher.js
@@ -14,7 +14,8 @@ var fs = require('fs')
 var fileutils = require('./fileutils')
 var browserExeExists = fileutils.browserExeExists
 var findableByWhich = fileutils.findableByWhich
-var findableByWhere = fileutils.findableByWhere
+var findableByWhichOrModule = fileutils.findableByWhichOrModule
+var findableByWhereOrModule = fileutils.findableByWhereOrModule
 var os = require('os')
 
 // Find the temporary directory for the system
@@ -119,7 +120,7 @@ function browsersForPlatform(){
         name: 'PhantomJS',
         exe: 'phantomjs',
         args: buildPhantomJsArgs,
-        supported: findableByWhere
+        supported: findableByWhereOrModule
       }
     ]
   }else if (platform === 'darwin'){
@@ -176,7 +177,7 @@ function browsersForPlatform(){
         name: 'PhantomJS',
         exe: 'phantomjs',
         args: buildPhantomJsArgs,
-        supported: findableByWhich
+        supported: findableByWhichOrModule
       }
     ]
   }else if (platform === 'linux'){
@@ -220,7 +221,7 @@ function browsersForPlatform(){
         name: 'PhantomJS',
         exe: 'phantomjs',
         args: buildPhantomJsArgs,
-        supported: findableByWhich
+        supported: findableByWhichOrModule
       }
     ]
   }else if (platform === 'sunos') {
@@ -229,7 +230,7 @@ function browsersForPlatform(){
           name: 'PhantomJS',
           exe: 'phantomjs',
           args: buildPhantomJsArgs,
-          supported: findableByWhich
+          supported: findableByWhichOrModule
         }
   	]
   }else{

--- a/lib/fileutils.js
+++ b/lib/fileutils.js
@@ -18,6 +18,9 @@ exports.findableByWhere = findableByWhere
 var findableByWhich = findableBy(which)
 exports.findableByWhich = findableByWhich
 
+exports.findableByWhichOrModule = findableByTypeOrModule(which)
+exports.findableByWhereOrModule = findableByTypeOrModule(where)
+
 function findableBy(func, cb){
   return function(cb){
     var browser = this
@@ -28,6 +31,41 @@ function findableBy(func, cb){
     else
       func(browser.exe, cb)
   }
+}
+
+function findableByTypeOrModule(type) {
+  return function(cb) {
+    var browser = this
+    findableByModule.call(browser, function(findable){
+      if(findable){
+        cb(findable)
+      }else{
+        findableBy(type).call(browser, cb)
+      }
+    })
+  }
+}
+
+function resolveModule(exe){
+  var nodeModule
+  var nodeModuleBin
+  try {
+    nodeModule = require(exe)
+    nodeModuleBin = nodeModule.path
+  } catch(err) {
+    nodeModule = null
+    nodeModuleBin = null
+  }
+  return nodeModuleBin
+}
+
+function findableByModule(cb){
+  var browser = this
+  var moduleBin = resolveModule(browser.exe)
+  if(moduleBin){
+    browser.exe = moduleBin
+  }
+  cb(!!moduleBin)
 }
 
 exports.where = where


### PR DESCRIPTION
Add the ability to find phantomjs by node module resolution if which fails. This will allow people to have phantomjs installed in their local node_modules folder instead of requiring it to be installed globally.