### PR TITLE
Proposal: Separate testem connection into an iframe

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -197,8 +197,6 @@ Server.prototype = {
 
     res.write(';(function(){')
     var files = [
-      'save_window.js',
-      require.resolve('socket.io/node_modules/socket.io-client/socket.io.js'),
       'decycle.js',
       'jasmine_adapter.js',
       'jasmine2_adapter.js',

--- a/public/testem/connection.html
+++ b/public/testem/connection.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="/socket.io/socket.io.js"></script>
+  <script src="/testem/decycle.js"></script>
+  <script src="/testem/testem_connection.js"></script>
+  <style>
+  body {
+    background: transparent;
+  }
+  #__testem_ui__ {
+    position: fixed;
+    bottom: 5px;
+    right: 5px;
+    background-color: #444;
+    padding: 3px;
+    color: #fff;
+    font-family: Monaco, monospace;
+    text-transform: uppercase;
+    opacity: 0.8;
+  }
+  #__testem_ui__.connected {
+    color: #89e583;
+  }
+  #__testem_ui__.disconnected {
+    color: #cc7575;
+  }
+  </style>
+</head>
+
+<body></body>
+
+</html>

--- a/public/testem/save_window.js
+++ b/public/testem/save_window.js
@@ -1,4 +1,0 @@
-// Save references to window variables, which are likely to be mocked, but
-// required by testem
-
-var XMLHttpRequest = window.XMLHttpRequest;

--- a/public/testem/testem_connection.js
+++ b/public/testem/testem_connection.js
@@ -1,0 +1,116 @@
+
+var socket, connectStatus = 'disconnected'
+
+function syncConnectStatus(){
+  var elm = document.getElementById('__testem_ui__')
+  if (elm) elm.className = connectStatus
+}
+
+function startTests(){
+  socket.disconnect()
+  parent.window.location.reload()
+}
+
+function initUI(){
+  var markup = 'TEST\u0027EM \u0027SCRIPTS!'
+  var elm = document.createElement('div')
+  elm.id = '__testem_ui__'
+  elm.className = connectStatus
+  elm.innerHTML = markup
+  document.body.appendChild(elm)
+}
+
+function getBrowserName(userAgent){
+  var regexs = [
+    /MS(?:(IE) (1?[0-9]\.[0-9]))/,
+    [/Trident\/.* rv:(1?[0-9]\.[0-9])/, function(m) {
+      return ['IE', m[1]].join(' ')
+    }],
+    [/(OPR)\/([0-9]+\.[0-9]+)/, function(m){
+      return ['Opera', m[2]].join(' ')
+    }],
+    /(Opera).*Version\/([0-9]+\.[0-9]+)/,
+    /(Chrome)\/([0-9]+\.[0-9]+)/,
+    /(Firefox)\/([0-9a-z]+\.[0-9a-z]+)/,
+    /(PhantomJS)\/([0-9]+\.[0-9]+)/,
+    [/(Android).*Version\/([0-9]+\.[0-9]+).*(Safari)/, function(m){
+      return [m[1], m[3], m[2]].join(' ')
+    }],
+    [/(iPhone).*Version\/([0-9]+\.[0-9]+).*(Safari)/, function(m){
+      return [m[1], m[3], m[2]].join(' ')
+    }],
+    [/(iPad).*Version\/([0-9]+\.[0-9]+).*(Safari)/, function(m){
+      return [m[1], m[3], m[2]].join(' ')
+    }],
+    [/Version\/([0-9]+\.[0-9]+).*(Safari)/, function(m){
+      return [m[2], m[1]].join(' ')
+    }]
+  ]
+  var defaultPick = function(m) {
+    return m.slice(1).join(' ')
+  }
+
+  for (var i = 0; i < regexs.length; i++){
+    var regex = regexs[i]
+    var pick = defaultPick
+    if (regex instanceof Array) {
+      pick = regex[1]
+      regex = regex[0]
+    }
+    var match = userAgent.match(regex)
+    if (match){
+      return pick(match)
+    }
+  }
+  return userAgent
+}
+
+function getId(){
+  var m = parent.location.pathname.match(/^\/([0-9]+)/)
+  return m ? m[1] : null
+}
+
+
+var addListener = window.addEventListener ?
+  function(obj, evt, cb){ obj.addEventListener(evt, cb, false) } :
+  function(obj, evt, cb){ obj.attachEvent('on' + evt, cb) }
+
+function init(){
+  socket = io.connect({ reconnectionDelayMax: 1000, randomizationFactor: 0 })
+  var id = getId()
+  socket.emit('browser-login',
+    getBrowserName(navigator.userAgent),
+    id)
+  socket.on('connect', function(){
+    connectStatus = 'connected'
+    syncConnectStatus()
+  })
+  socket.on('disconnect', function(){
+    connectStatus = 'disconnected'
+    syncConnectStatus()
+  })
+  socket.on('reconnect', startTests)
+  socket.on('start-tests', startTests)
+
+  addListener(window, 'load', initUI)
+
+  while (parent.Testem.emitConnectionQueue.length > 0) {
+    TestemConnection.emit.apply(this, parent.Testem.emitConnectionQueue.shift());
+  }
+  parent.Testem.emitConnection = TestemConnection.emit;
+}
+
+window.TestemConnection = {
+  emit: function() {
+    var args = Array.prototype.slice.apply(arguments);
+    // Workaround IE 8 max instructions
+    setTimeout(function() {
+      var decycled = decycle(args);
+      setTimeout(function() {
+        socket.emit.apply(socket, decycled);
+      }, 0);
+    }, 0);
+  }
+}
+
+init()


### PR DESCRIPTION
Prevent leaking code from testem into tested application and vice versa

This prevents issues like https://github.com/airportyh/testem/pull/455 in the furture.

@airportyh I tried to introduce no breaking changes, but I think this should be released as 0.7. What do you think? 