### PR TITLE
Print https scheme if use key or pfx config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -114,7 +114,11 @@ Config.prototype.defaults = {
   host: 'localhost',
   port: 7357,
   url: function(){
-    return 'http://' + this.get('host') + ':' + this.get('port') + '/'
+    var scheme = 'http';
+    if (this.get('key') || this.get('pfx')){
+      scheme = 'https';
+    }
+    return scheme + '://' + this.get('host') + ':' + this.get('port') + '/'
   },
   parallel: 1,
   reporter: 'tap'


### PR DESCRIPTION
Show https scheme of url on testem window if use "key" or "pfx" config. Fixes #523