### PR TITLE
Xml writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Testem has other test reporters than TAP: `dot` and `xunit`. You can use the `-R
 ### Example xunit reporter output
 
 Note that the real output is not pretty printed.
-'''
+'''xml
 <testsuite name="Testem Tests" tests="4" failures="1" timestamp="Wed Apr 01 2015 11:56:20 GMT+0100 (GMT Daylight Time)" time="9">
   <testcase classname="PhantomJS 1.9" name="myFunc returns true when input is valid" time="0"/>
   <testcase classname="PhantomJS 1.9" name="myFunc returns false when user tickles it" time="0"/>

--- a/README.md
+++ b/README.md
@@ -167,6 +167,24 @@ Testem has other test reporters than TAP: `dot` and `xunit`. You can use the `-R
 
     testem ci -R dot
 
+### Example xunit reporter output
+
+Note that the real output is not pretty printed.
+'''
+<testsuite name="Testem Tests" tests="4" failures="1" timestamp="Wed Apr 01 2015 11:56:20 GMT+0100 (GMT Daylight Time)" time="9">
+  <testcase classname="PhantomJS 1.9" name="myFunc returns true when input is valid" time="0"/>
+  <testcase classname="PhantomJS 1.9" name="myFunc returns false when user tickles it" time="0"/>
+  <testcase classname="Chrome" name="myFunc returns true when input is valid" time="0"/>
+  <testcase classname="Chrome" name="myFunc returns false when user tickles it" time="0">
+    <failure name="myFunc returns false when user tickles it" message="function is not ticklish">
+      <![CDATA[
+      Callstack...
+      ]]>
+    </failure>
+  </testcase>
+</testsuite>
+'''
+
 ### Command line options
 
 To see all command line options for CI

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Testem has other test reporters than TAP: `dot` and `xunit`. You can use the `-R
 ### Example xunit reporter output
 
 Note that the real output is not pretty printed.
-'''xml
+```xml
 <testsuite name="Testem Tests" tests="4" failures="1" timestamp="Wed Apr 01 2015 11:56:20 GMT+0100 (GMT Daylight Time)" time="9">
   <testcase classname="PhantomJS 1.9" name="myFunc returns true when input is valid" time="0"/>
   <testcase classname="PhantomJS 1.9" name="myFunc returns false when user tickles it" time="0"/>
@@ -183,7 +183,7 @@ Note that the real output is not pretty printed.
     </failure>
   </testcase>
 </testsuite>
-'''
+```
 
 ### Command line options
 

--- a/lib/ci/test_reporters/xunit_reporter.js
+++ b/lib/ci/test_reporters/xunit_reporter.js
@@ -1,5 +1,5 @@
 var strutils = require('../../strutils')
-var xmlescape = require('xml-escape');
+var XmlDom = require('xmldom')
 
 
 function XUnitReporter(silent, out){
@@ -29,31 +29,44 @@ XUnitReporter.prototype = {
     this.out.write('\n')
   },
   summaryDisplay: function(){
-    return '<testsuite name="Testem Tests" tests="' + this.total +
-      '" failures="' + this.failures() + '" timestamp="' + new Date +
-      '" time="' + this.duration() + '">\n' +
-      this.results.map(function(result){
-        return this.renderTestResult(result)
-      }, this).join('\n') +
-      '\n</testsuite>'
+    var doc = new XmlDom.DOMImplementation().createDocument('','testsuite')
+
+    var rootNode = doc.documentElement
+    rootNode.setAttribute('name', 'Testem Tests');
+    rootNode.setAttribute('tests', this.total);
+    rootNode.setAttribute('failures', this.failures());
+    rootNode.setAttribute('timestamp', new Date);
+    rootNode.setAttribute('time', this.duration());
+
+    for (var i = 0, len = this.results.length; i < len; i++) {
+      var testcaseNode = this.getTestResultNode(doc, this.results[i])
+      rootNode.appendChild(testcaseNode)
+    }
+
+    return new XmlDom.XMLSerializer().serializeToString(doc.documentElement);
   },
-  renderTestResult: function(result){
+  getTestResultNode: function(document, result){
     var launcher = result.launcher
     result = result.result
+
+    var resultNode = document.createElement('testcase');
+    resultNode.setAttribute('classname', launcher);
+    resultNode.setAttribute('name', result.name);
+    resultNode.setAttribute('time', 0);
+
     var error = result.error
-    var testname = xmlescape(result.name);
-    if (error){
-      var errorMessage = xmlescape(error.message);
-      return '  <testcase name="' +
-        launcher + ' ' + testname + '">' +
-        '<failure name="' + testname + '" ' +
-        'message="' + errorMessage + '">' +
-        (!error.stack ? '' : '<![CDATA[' + error.stack + ']]>') +
-        '</failure></testcase>'
-    }else{
-      return '  <testcase name="' +
-        launcher + ' ' + testname + '"/>'
+    if (error) {
+      var failureNode = document.createElement('failure');
+      failureNode.setAttribute('name', result.name);
+      failureNode.setAttribute('message', error.message);
+      if (error.stack)
+      {
+        var cdata = document.createCDATASection(error.stack)
+        failureNode.appendChild(cdata);
+      }
+      resultNode.appendChild(failureNode)
     }
+    return resultNode
   },
   failures: function(){
     return this.total - this.pass

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "socket.io": "^1.3.4",
     "styled_string": "0.0.1",
     "tap": "^0.6.0",
-    "xml-escape": "^1.0.0"
+    "xmldom": "^0.1.19"
   },
   "files": [
     "lib",

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -2,6 +2,7 @@ var TapReporter = require('../../lib/ci/test_reporters/tap_reporter')
 var DotReporter = require('../../lib/ci/test_reporters/dot_reporter')
 var XUnitReporter = require('../../lib/ci/test_reporters/xunit_reporter')
 var PassThrough = require('stream').PassThrough
+var XmlDom = require('xmldom')
 var assert = require('chai').assert
 
 describe('test reporters', function(){
@@ -60,6 +61,8 @@ describe('test reporters', function(){
       var output = stream.read().toString()
       assert.match(output, /  \./)
       assert.match(output, /1 tests complete \([0-9]+ ms\)/)
+
+      assertXmlIsValid(output)
     })
 
     it('writes out errors', function(){
@@ -92,7 +95,9 @@ describe('test reporters', function(){
       reporter.finish()
       var output = stream.read().toString()
       assert.match(output, /<testsuite name="Testem Tests" tests="1" failures="0" timestamp="(.+)" time="([0-9]+)">/)
-      assert.match(output, /<testcase name="phantomjs it does &lt;cool&gt; &quot;cool&quot; &apos;cool&apos; stuff"\/>/)
+      assert.match(output, /<testcase classname="phantomjs" name="it does &lt;cool> &quot;cool&quot; \'cool\' stuff"/)
+
+      assertXmlIsValid(output)
     })
     it('outputs errors', function(){
       var stream = new PassThrough()
@@ -106,8 +111,10 @@ describe('test reporters', function(){
       })
       reporter.finish()
       var output = stream.read().toString()
-      assert.match(output, /it didnt work"><failure/)
+      assert.match(output, /it didnt work"/)
       assert.match(output, /it crapped out/)
+
+      assertXmlIsValid(output)
     })
     it('XML escapes errors', function(){
       var stream = new PassThrough()
@@ -121,8 +128,10 @@ describe('test reporters', function(){
       })
       reporter.finish()
       var output = stream.read().toString()
-      assert.match(output, /it failed with quotes"><failure/)
-      assert.match(output, /&lt;it&gt; &quot;crapped&quot; out/)
+      assert.match(output, /it failed with quotes"/)
+      assert.match(output, /&lt;it> &quot;crapped&quot; out/)
+
+      assertXmlIsValid(output)
     })
     it('XML escapes messages', function(){
       var stream = new PassThrough()
@@ -132,13 +141,50 @@ describe('test reporters', function(){
         passed: 0,
         total: 1,
         failed: 1,
-        error: { message: "managers/slide-preview.js should pass jshint.managers/slide-preview.js: line 34, col 13, Expected '{' and instead saw 'return'.managers/slide-preview.js: line 51, col 13, Expected '{' and instead saw 'return'.managers/slide-preview.js: line 99, col 13, Expected '{' and instead saw 'return'.managers/slide-preview.js: line 106, col 13, Expected '{' and instead saw 'return'.managers/slide-preview.js: line 113, col 13, Expected '{' and instead saw 'return'.managers/slide-preview.js: line 122, col 13, Expected '{' and instead saw 'return'.managers/slide-preview.js: line 146, col 13, Expected '{' and instead saw 'return'.managers/slide-preview.js: line 156, col 13, Expected '{' and instead saw 'return'.managers/slide-preview.js: line 160, col 17, Bad line breaking before '&&'.managers/slide-preview.js: line 234, col 47, Expected a 'break' statement before 'default'.managers/slide-preview.js: line 264, col 68, Expected an assignment or function call and instead saw an expression.managers/slide-preview.js: line 209, col 13, 'slide' is defined but never used.managers/slide-preview.js: line 256, col 13, 'remainingPreviews' is defined but never used.13 errors" }
+        error: { message: "&&" }
       })
       reporter.finish()
       var output = stream.read().toString()
-      assert.match(output, /it failed with ampersands"><failure/)
+      assert.match(output, /it failed with ampersands"/)
       assert.match(output, /&amp;&amp;/)
+
+      assertXmlIsValid(output)
+    })
+    it('presents valid XML with null messages', function(){
+      var stream = new PassThrough()
+      var reporter = new XUnitReporter(false, stream)
+      reporter.report('phantomjs', {
+        name: 'null',
+        passed: 0,
+        total: 1,
+        failed: 1,
+        error: { message: null }
+      })
+      reporter.finish()
+      var output = stream.read().toString()
+
+      assertXmlIsValid(output)
     })
   })
+
+var assertXmlIsValid = function(xmlString) {
+  var failure = null;
+  var parser = new XmlDom.DOMParser({
+    errorHandler:{
+      locator:{},
+      warning: function(txt) { failure = txt; },
+      error: function(txt) { failure = txt; },
+      fatalError: function(txt) { failure = txt; }
+    }
+  })
+
+  // this will throw into failure variable with invalid xml
+  parser.parseFromString(xmlString,'text/xml')
+
+  if (failure)
+  {
+    assert(false, failure+'\n---\n'+xmlString+'\n---\n')
+  }
+}
 
 })

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -99,9 +99,9 @@ describe('test reporters', function(){
       var reporter = new XUnitReporter(false, stream)
       reporter.report('phantomjs', {
         name: 'it didnt work',
-        passed: 1,
+        passed: 0,
         total: 1,
-        failed: 0,
+        failed: 1,
         error: new Error('it crapped out')
       })
       reporter.finish()
@@ -114,15 +114,30 @@ describe('test reporters', function(){
       var reporter = new XUnitReporter(false, stream)
       reporter.report('phantomjs', {
         name: 'it failed with quotes',
-        passed: 1,
+        passed: 0,
         total: 1,
-        failed: 0,
+        failed: 1,
         error: new Error('<it> \"crapped\" out')
       })
       reporter.finish()
       var output = stream.read().toString()
       assert.match(output, /it failed with quotes"><failure/)
       assert.match(output, /&lt;it&gt; &quot;crapped&quot; out/)
+    })
+    it('XML escapes messages', function(){
+      var stream = new PassThrough()
+      var reporter = new XUnitReporter(false, stream)
+      reporter.report('phantomjs', {
+        name: 'it failed with ampersands',
+        passed: 0,
+        total: 1,
+        failed: 1,
+        error: { message: "managers/slide-preview.js should pass jshint.managers/slide-preview.js: line 34, col 13, Expected '{' and instead saw 'return'.managers/slide-preview.js: line 51, col 13, Expected '{' and instead saw 'return'.managers/slide-preview.js: line 99, col 13, Expected '{' and instead saw 'return'.managers/slide-preview.js: line 106, col 13, Expected '{' and instead saw 'return'.managers/slide-preview.js: line 113, col 13, Expected '{' and instead saw 'return'.managers/slide-preview.js: line 122, col 13, Expected '{' and instead saw 'return'.managers/slide-preview.js: line 146, col 13, Expected '{' and instead saw 'return'.managers/slide-preview.js: line 156, col 13, Expected '{' and instead saw 'return'.managers/slide-preview.js: line 160, col 17, Bad line breaking before '&&'.managers/slide-preview.js: line 234, col 47, Expected a 'break' statement before 'default'.managers/slide-preview.js: line 264, col 68, Expected an assignment or function call and instead saw an expression.managers/slide-preview.js: line 209, col 13, 'slide' is defined but never used.managers/slide-preview.js: line 256, col 13, 'remainingPreviews' is defined but never used.13 errors" }
+      })
+      reporter.finish()
+      var output = stream.read().toString()
+      assert.match(output, /it failed with ampersands"><failure/)
+      assert.match(output, /&amp;&amp;/)
     })
   })
 


### PR DESCRIPTION
Fixes https://github.com/airportyh/testem/issues/529

Switched to using DOM rather than string concatenation. This forces correct escaping of xml, and will handle unicode better later. Also code is much more explicit and readable.