### PR TITLE
Handle net.Server.close() throws "Not running"

### DIFF
--- a/lib/ci/index.js
+++ b/lib/ci/index.js
@@ -147,6 +147,10 @@ App.prototype = {
     this.reporter.finish()
     this.emit('tests-finish')
     this.stopHookRunners()
+    if (err && /^Testem Server Error/.test(err.message)){
+      this.stopped = true
+      return this.exit()
+    }
     this.stopServer(this.exit.bind(this))
   },
 

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -46,15 +46,7 @@ Server.prototype = {
   },
   stop: function(callback){
     if (this.server) {
-      try {
-        this.server.close(callback)
-      } catch (error){
-        if (error.message === "Not running"){
-          // For compatability with Node v0.11.13 and earlier which didn't
-          // have this commit https://github.com/joyent/node/commit/f1dc55
-          callback()
-        }
-      }
+      this.server.close(callback)
     }
     else {
       callback()

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -46,7 +46,15 @@ Server.prototype = {
   },
   stop: function(callback){
     if (this.server) {
-      this.server.close(callback)
+      try {
+        this.server.close(callback)
+      } catch (error){
+        if (error.message === "Not running"){
+          // For compatability with Node v0.11.13 and earlier which didn't
+          // have this commit https://github.com/joyent/node/commit/f1dc55
+          callback()
+        }
+      }
     }
     else {
       callback()

--- a/tests/ci/ci_tests.js
+++ b/tests/ci/ci_tests.js
@@ -103,6 +103,25 @@ describe('ci mode app', function(){
     assert.equal(result.error.message, 'blarg')
   })
 
+  it('does not try to stop server if Testem Server Error occurs', function(){
+    var app = new App(new Config('ci'))
+    stub(app, 'stopServer')
+    stub(app, 'exit')
+
+    app.wrapUp(new Error('Testem Server Error: foo'))
+    assert(!app.stopServer.called, 'stop server should not be called')
+    assert(app.exit.called, 'exit should be called')
+  })
+
+  it('stops server if non- Testem Server Error occurs', function(){
+    var app = new App(new Config('ci'))
+    stub(app, 'stopServer')
+    stub(app, 'exit')
+
+    app.wrapUp(new Error('Not Testem Server Error: foo'))
+    assert(app.stopServer.called, 'stop server should be called')
+  })
+
   describe('getExitCode', function(){
 
     it('returns 0 if all passed', function(){


### PR DESCRIPTION
For backwards compatability with node v0.11.13 and earlier

This can occur when testem tries to connect with a port that is already in use. This was exposed by https://github.com/airportyh/testem/commit/0c63c8

Alternatively, we can modify the README to state node >= 0.11.14 is required (currently it's at 0.6.2)