### PR TITLE
No restart on reconnect

### DIFF
--- a/public/testem/testem_connection.js
+++ b/public/testem/testem_connection.js
@@ -89,9 +89,7 @@ function init(){
     connectStatus = 'disconnected'
     syncConnectStatus()
   })
-  socket.on('reconnect', startTests)
   socket.on('start-tests', startTests)
-
   addListener(window, 'load', initUI)
 
   while (parent.Testem.emitConnectionQueue.length > 0) {


### PR DESCRIPTION
This should improve reliability of test suites, which including remote
browsers (like SauceLabs). The socket.io client takes care of buffering
messages, when the connection is currently not available.