### PR TITLE
Height/weight styling for connection.html

### DIFF
--- a/public/testem/connection.html
+++ b/public/testem/connection.html
@@ -12,6 +12,8 @@
     position: fixed;
     bottom: 5px;
     right: 5px;
+    height: 85px;
+    width: 180px;
     background-color: #444;
     padding: 3px;
     color: #fff;


### PR DESCRIPTION
When connection.html is loaded in an iframe, it inherits the height/width from the parent element, causing it to take up the entire page. This prevents users from clicking anything on the page. This just adds very basic styling to prevent that from happening.
