### PR TITLE
Add ~/Applications to Testem search paths in MacOS

### DIFF
--- a/lib/browser_launcher.js
+++ b/lib/browser_launcher.js
@@ -128,7 +128,10 @@ function browsersForPlatform(){
     return [
       {
         name: "Chrome",
-        exe: "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome",
+        exe: [
+          process.env.HOME + "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome",
+          "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome"
+        ],
         args: ["--user-data-dir=" + tempDir + "/testem.chrome", "--no-default-browser-check", "--no-first-run", "--ignore-certificate-errors"],
         setup: function(config, done){
           rimraf(tempDir + '/testem.chrome', done)
@@ -137,7 +140,10 @@ function browsersForPlatform(){
       },
       {
         name: "Chrome Canary",
-        exe: "/Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary",
+        exe: [
+          process.env.HOME + "/Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary",
+          "/Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary"
+        ],
         args: ["--user-data-dir=" + tempDir + "/testem.chrome-canary", "--no-default-browser-check", "--no-first-run", "--ignore-certificate-errors"],
         setup: function(config, done){
           rimraf(tempDir + '/testem.chrome-canary', done)
@@ -146,7 +152,10 @@ function browsersForPlatform(){
       },
       {
         name: "Firefox",
-        exe: "/Applications/Firefox.app/Contents/MacOS/firefox",
+        exe: [
+          process.env.HOME + "/Applications/Firefox.app/Contents/MacOS/firefox",
+          "/Applications/Firefox.app/Contents/MacOS/firefox"
+        ],
         args: ["-profile", tempDir + "/testem.firefox"],
         setup: function(config, done){
           setupFirefoxProfile(tempDir + '/testem.firefox', done)
@@ -155,7 +164,10 @@ function browsersForPlatform(){
       },
       {
         name: "Safari",
-        exe: "/Applications/Safari.app/Contents/MacOS/Safari",
+        exe: [
+          process.env.HOME + "/Applications/Safari.app/Contents/MacOS/Safari",
+          "/Applications/Safari.app/Contents/MacOS/Safari"
+        ],
         setup: function(config, done){
           var url = this.getUrl()
           fs.writeFile(tempDir + '/testem.safari.html', "<script>window.location = '" + url + "'</script>", done)
@@ -167,7 +179,10 @@ function browsersForPlatform(){
       },
       {
         name: "Opera",
-        exe: "/Applications/Opera.app/Contents/MacOS/Opera",
+        exe: [
+          process.env.HOME + "/Applications/Opera.app/Contents/MacOS/Opera",
+          "/Applications/Opera.app/Contents/MacOS/Opera"
+        ],
         args: ["-pd", tempDir + "/testem.opera", "--user-data-dir=" + tempDir + "/testem.opera"],
         setup: function(config, done){
           rimraf(tempDir + '/testem.opera', done)


### PR DESCRIPTION
This add support for browsers installed with [homebrew-cask](https://github.com/caskroom/homebrew-cask), since it installs everything in `~/Applications`.