### PR TITLE
Use setRawMode just when tty is avaliable

### DIFF
--- a/lib/dev/ui/appview.js
+++ b/lib/dev/ui/appview.js
@@ -250,15 +250,19 @@ var AppView = module.exports = View.extend({
   isPopupVisible: function(){
     return !! this.get('isPopupVisible')
   },
+  setRawMode: function() {
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(false)
+    }
+  },
   cleanup: function(cb){
-
     var screen = this.get('screen')
     screen.display('reset')
     screen.erase('screen')
     screen.position(0, 0)
     screen.enableScroll()
     screen.cursor(true)
-    process.stdin.setRawMode(false)
+    this.setRawMode(false)
     screen.destroy()
     if (cb) cb()
   }


### PR DESCRIPTION
I hit this problem while using testem as a subprocess in a integration test.
In the end of my test I send a `"q"` to testem stdin in order to quit the dev server, but it always fail with undefined is not a function error.