### PR TITLE
In CI app, clean up launchers on SIGINT or SIGTERM

### DIFF
--- a/lib/ci/index.js
+++ b/lib/ci/index.js
@@ -54,6 +54,7 @@ App.prototype = {
   start: function(){
     log.info('Starting ci')
     async.series([
+      this.addSignalListeners.bind(this),
       this.startServer.bind(this),
       this.runHook.bind(this, 'on_start'),
       this.runHook.bind(this, 'before_tests'),
@@ -147,11 +148,21 @@ App.prototype = {
     this.reporter.finish()
     this.emit('tests-finish')
     this.stopHookRunners()
+    var series
     if (err && /^Testem Server Error/.test(err.message)){
       this.stopped = true
-      return this.exit()
+      series = [
+        this.cleanUpLaunchers.bind(this),
+        this.removeSignalListeners.bind(this)
+      ]
+    } else {
+      series = [
+        this.cleanUpLaunchers.bind(this),
+        this.stopServer.bind(this),
+        this.removeSignalListeners.bind(this)
+      ]
     }
-    this.stopServer(this.exit.bind(this))
+    async.series(series, this.exit.bind(this))
   },
 
   stopServer: function(callback){
@@ -180,6 +191,47 @@ App.prototype = {
     if (this.exited) return
     this.cleanExit(this.getExitCode())
     this.exited = true
+  },
+
+  addSignalListeners: function(callback) {
+    this._boundSigInterrupt = function() {
+      this.wrapUp(new Error('Received SIGINT signal'))
+    }.bind(this)
+    process.on('SIGINT', this._boundSigInterrupt)
+
+    this._boundSigTerminate = function() {
+      this.wrapUp(new Error('Received SIGTERM signal'))
+    }.bind(this)
+    process.on('SIGTERM', this._boundSigTerminate)
+
+    callback()
+  },
+
+  removeSignalListeners: function(callback) {
+    if (this._boundSigInterrupt) {
+      process.removeListener('SIGINT', this._boundSigInterrupt)
+    }
+    if (this._boundSigTerminate) {
+      process.removeListener('SIGTERM', this._boundSigTerminate)
+    }
+    callback()
+  },
+
+  cleanUpLaunchers: function(callback){
+    if (!this.runners){
+      if (callback) callback()
+      return
+    }
+    var launchers = this.runners.map(function(runner) {
+      return runner.launcher
+    })
+    async.forEach(launchers, function(launcher, done){
+      if (launcher && launcher.process){
+        launcher.kill('SIGTERM', done)
+      }else{
+        done()
+      }
+    }, callback)
   }
 }
 

--- a/tests/fixtures/fail_later/test.js
+++ b/tests/fixtures/fail_later/test.js
@@ -1,0 +1,10 @@
+describe('I fail', function(){
+  it('later', function(){
+    waitsFor(function() {
+      return false
+    }, '', 30000)
+    runs(function() {
+      throw new Error('oops')
+    })
+  })
+})


### PR DESCRIPTION
If SIGINT or SIGTERM is sent to the testem process in CI app, clean up
the launchers so that they aren't sitting around afterwords.