### PR TITLE
Allow to disable file watching

### DIFF
--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -30,7 +30,7 @@ Common Configuration Options
 * **src_files** - the location of your source files. This should be the code that you author directly, and not generated source files. So, if you are writing in CoffeeScript or TypeScript, this should be your `.coffee` or `.ts` files. If you are writing in Javascript, this would just be your `.js` files, but if you have a compile step for your JS, this would be the `.js` file pre-compilation. The files matched here are what Testem watches for modification (the *watch list*) so that it promptly re-runs the tests when any of them are saved.
 * **serve_files** - the location of the source files to be served to the browser. If don't have a compilation step, don't set this option, and it will default to *src_files*. If you have a compilation step, you should set this to the `*.js` file(s) that result from the compilation.
 * **test_page** - if you want to use a custom test page to run your tests, put its path here. In most cases, when you use this option, the *src_files* option becomes unnecessary because Testem simply adds all requested files into the watch list. You will also make sure that you include the `/testem.js` script in your test page if you use this option - simply include it with a script tag just below the include for your test framework, i.e. `jasmine.js`.
-* **launchers** - this option allows you to set up custom process launchers which can be used to run Node programs and indeed any kind of process within Testem. 
+* **launchers** - this option allows you to set up custom process launchers which can be used to run Node programs and indeed any kind of process within Testem.
 
 ## Option Reference
 
@@ -66,7 +66,8 @@ Common Configuration Options
     fail_on_zero_tests:     [Boolean] whether process should exit with error status when no tests found  
     unsafe_file_serving:    [Boolean] allow serving directories that are not in your CWD (false)
     reporter:               [String]  name of the reporter to be used in ci mode (tap, xunit, dot)
-    
+    disable_watching:       [Boolean] disable any file watching
+
 
 ### Available hooks:
 

--- a/lib/dev/index.js
+++ b/lib/dev/index.js
@@ -20,7 +20,7 @@ var fireworm = require('fireworm')
 var StyledString = require('styled_string')
 var cleanExit = require('../clean_exit')
 
-function App(config, finalizer){
+function App(config, finalizer, cb){
   var self = this
 
   this.config = config
@@ -37,18 +37,23 @@ function App(config, finalizer){
       }
     })
 
+  var quiteGracefully = function(err) {
+    console.error(err, err.stack)
+    self.quit(1, err)
+  }
+
+  process.on('uncaughtException', quiteGracefully)
 
   this.exited = false
   this.paused = false
-  this.finalizer = finalizer || cleanExit
-  this.fileWatcher = fireworm('./', {
-    ignoreInitial: true
-  })
-  var onFileChanged = this.onFileChanged.bind(this)
-  this.fileWatcher.on('change', onFileChanged)
-  this.fileWatcher.on('add', onFileChanged)
-  this.fileWatcher.on('remove', onFileChanged)
-  this.fileWatcher.on('emfile', this.onEMFILE.bind(this))
+  this.finalizer = function(code, cb) {
+    var fn = finalizer || cleanExit
+    process.removeListener('uncaughtException', quiteGracefully)
+    fn(code);
+    if (cb) {
+      cb();
+    }
+  }
 
   // a list of connected browser clients
   this.runners.on('remove', function(runner){
@@ -63,14 +68,8 @@ function App(config, finalizer){
     this.server.on('file-requested', this.onFileRequested.bind(this))
     this.server.on('browser-login', this.onBrowserLogin.bind(this))
     this.server.on('server-error', this.onServerError.bind(this))
-    this.server.start()
+    this.server.start(cb)
   })
-
-  process.on('uncaughtException', function(err){
-    console.error(err)
-    self.quit(1, err)
-  })
-
 }
 
 App.prototype = {
@@ -135,9 +134,26 @@ App.prototype = {
   },
   configure: function(cb){
     var self = this
-    var fileWatcher = self.fileWatcher
     var config = self.config
     config.read(function(){
+      if (config.get('disable_watching')) {
+        if (cb) {
+          cb.call(self)
+        }
+
+        return
+      }
+
+      self.fileWatcher = fireworm('./', {
+        ignoreInitial: true
+      })
+      var onFileChanged = self.onFileChanged.bind(self)
+      self.fileWatcher.on('change', onFileChanged)
+      self.fileWatcher.on('add', onFileChanged)
+      self.fileWatcher.on('remove', onFileChanged)
+      self.fileWatcher.on('emfile', self.onEMFILE.bind(self))
+
+      var fileWatcher = self.fileWatcher
       var watchFiles = config.get('watch_files')
       fileWatcher.clear()
       var confFile = config.get('file')
@@ -156,11 +172,13 @@ App.prototype = {
       if (ignoreFiles){
         fileWatcher.ignore(ignoreFiles)
       }
-      if (cb) cb.call(self)
+      if (cb) {
+        cb.call(self)
+      }
     })
   },
   onFileRequested: function(filepath){
-    if (!this.config.get('serve_files')){
+    if (this.fileWatcher && !this.config.get('serve_files')){
       this.fileWatcher.add(filepath)
     }
   },
@@ -196,25 +214,40 @@ App.prototype = {
   onBrowserLogin: function(browserName, id, client){
     this.connectBrowser(browserName, id, client)
   },
-  quit: function(code, err){
+  quit: function(code, err, cb){
     if (this.exited) return
 
     var self = this
     this.emit('exit')
-    this.cleanUpLaunchers(function(){
-      self.runExitHook(function(){
-        if (self.view && self.view.cleanup) {
-          self.view.cleanup(die)
-        }
-        else die()
-        function die(){
-          if (err) console.error(err.stack)
-          self.finalizer(code)
-          self.exited = true
-        }
+    this.cleanUpLaunchers(function() {
+      self.runExitHook(function() {
+        self.cleanupView(function() {
+          self.stopServer(function() {
+            if (err) console.error(err.stack)
+            self.finalizer(code, cb)
+            self.exited = true
+          })
+        })
       })
     })
   },
+
+  stopServer: function(cb) {
+    if (!this.server) {
+      return cb();
+    }
+
+    this.server.stop(cb);
+  },
+
+  cleanupView: function(cb) {
+    if (!this.view || !this.view.cleanup) {
+      return cb();
+    }
+
+    this.view.cleanup(cb);
+  },
+
   onInputChar: function(chr, i) {
     var self = this
     if (chr === 'q') {

--- a/tests/dev_tests.js
+++ b/tests/dev_tests.js
@@ -1,45 +1,91 @@
-var Backbone = require('backbone')
 var expect = require('chai').expect
 var Config = require('../lib/config')
 var DevApp = require('../lib/dev')
 var sinon = require('sinon')
+var fireworm = require('fireworm')
 
 var isWin = /^win/.test(process.platform)
 
 describe('Dev', !isWin ? function(){
   var app, config, sandbox
 
-  beforeEach(function(){
-    config = new Config('dev')
+  beforeEach(function() {
     sandbox = sinon.sandbox.create()
-    sandbox.stub(DevApp.prototype, "configureView")
-    sandbox.stub(DevApp.prototype, "configure")
-    app = new DevApp(config, function(){})
-    app.view = {
-      clearErrorPopupMessage: function(){}
-    }
   })
 
-  afterEach(function(){
+  afterEach(function() {
     sandbox.restore()
   })
 
-  it("starts off not paused", function(){
-    expect(app.paused).to.be.false
+  describe('pause running', function() {
+    beforeEach(function() {
+      config = new Config('dev')
+      sandbox.stub(DevApp.prototype, "configureView")
+      sandbox.stub(DevApp.prototype, "configure")
+      app = new DevApp(config, function(){})
+      app.view = {
+        clearErrorPopupMessage: function(){}
+      }
+    })
+
+    afterEach(function(done) {
+      app.quit(0, null, done)
+    })
+
+    it("starts off not paused", function(){
+      expect(app.paused).to.be.false
+    })
+
+    it("doesn't run tests when reset and paused", function() {
+      app.paused = true
+      var cb = sandbox.spy()
+      app.startTests(cb)
+      expect(cb.called).to.be.false
+    })
+
+    it("runs tests when reset and not paused", function() {
+      var cb = sandbox.spy()
+      app.startTests(cb)
+      expect(cb.called).to.be.true
+    })
   })
 
-  it("doesn't run tests when reset and paused", function() {
-    app.paused = true
-    var cb = sandbox.spy()
-    app.startTests(cb)
-    expect(cb.called).to.be.false
+  describe('file watching', function() {
+    beforeEach(function() {
+      sandbox.stub(DevApp.prototype, 'configureView')
+      sandbox.stub(Config.prototype, 'readConfigFile', function(file, cb) {
+        cb();
+      })
+    })
+
+    it('adds a watch', function(done) {
+      var add = sandbox.spy(fireworm.prototype, 'add');
+      var srcFiles = ['test.js'];
+      config = new Config('dev', {}, { src_files: srcFiles })
+      app = new DevApp(config, done, function() {
+        expect(add.getCall(0).args[0]).to.eq(srcFiles);
+        app.quit();
+      })
+      app.view = {
+        clearErrorPopupMessage: function(){}
+      }
+    })
+
+    it('creates no watcher', function(done) {
+      config = new Config('dev', {}, {
+        src_files: ['test.js'],
+        disable_watching: true
+      })
+      app = new DevApp(config, done, function() {
+        expect(app.fileWatcher).to.eq(undefined);
+        app.quit();
+      })
+      app.view = {
+        clearErrorPopupMessage: function(){}
+      }
+    })
   })
 
-  it("runs tests when reset and not paused", function() {
-    var cb = sandbox.spy()
-    app.startTests(cb)
-    expect(cb.called).to.be.true
-  })
 }: function() {
   xit('TODO: Fix and re-enable for windows')
 })


### PR DESCRIPTION
Introduced `disable_watching` option
quit now waits until the server stopped and unregisters event listeners

Fixes: https://github.com/airportyh/testem/issues/547