### PR TITLE
Force a single exe file for each browser once we found existing exe among other alternatives

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -103,6 +103,8 @@ Launcher.prototype = {
 
       if (Array.isArray(settings.exe)){
         async.filter(settings.exe, self.exeExists, function(found){
+          // since we found executable file we don't need array anymore in this run
+          self.settings.exe = found[0]
           spawn(found[0], settings.useCrossSpawn)
         })
       }else{

--- a/tests/launcher_tests.js
+++ b/tests/launcher_tests.js
@@ -176,6 +176,17 @@ describe('Launcher', function(){
       assert.equal(launcher.commandLine(), '"node -e console.log(process.argv.slice(1).join(\' \')) hello"')
     })
 
+    it('returns commandLine with a single exe', function(done){
+      settings = {exe: ['node', 'npm'], args: function(){ return ['-e', 'console.log(1)'] }}
+      config = new Config()
+      launcher = new Launcher('single exe', settings, config)
+      launcher.launch()
+      launcher.on('processExit', function(){
+        assert.equal(launcher.commandLine(), '"node -e console.log(1)"')
+        done()
+      })
+    })
+
     it('copies the current environment', function(done) {
       var originalEnv = process.env;
       process.env.TESTEM_USER_CONFIG = 'copied'


### PR DESCRIPTION
Browser launcher can try to find one of several executables (e.g. [chromium on Linux](https://github.com/airportyh/testem/blob/master/lib/browser_launcher.js#L228)). In this case we can see reports like this in CI:
```
Chromium - Browser "chromium,chromium-browser --user-data-dir=/tmp/testem.chromium --no-default-browser-check --no-first-run --ignore-certificate-errors http://localhost:7357/3463" exited unexpectedly.
```
I believe, once we figure out which one of alternative exes exists we can fix it in settings for the rest of the current testem run.