### PR TITLE
Allow arbitrary PhantomJS command line arguments

### DIFF
--- a/lib/browser_launcher.js
+++ b/lib/browser_launcher.js
@@ -48,6 +48,10 @@ function buildPhantomJsArgs(config) {
     options.unshift( "--remote-debugg" + "er-autorun=true" )
     options.unshift( "--remote-debugg" + "er-port=" + debug_port )
   }
+  var phantom_args = config.get("phantomjs_args")
+  if (phantom_args) {
+    options = phantom_args.concat(options)
+  }
   return options
 }
 


### PR DESCRIPTION
There are several features in PhantomJS that can only be controlled by
command line arguments. For example, without `--local-storage-quota` and
`--local-storage-path` you can't test any local storage features.

This change allows passing arbitrary argument through to phantom when it
is launched by testem. In your testem.json you would do:

    "phantomjs_args" : [
      "--local-storage-path=/tmp/phantom",
      "--local-storage-quota=100000"
    ]