### PR TITLE
Incorrect test count

### DIFF
--- a/lib/test_results.js
+++ b/lib/test_results.js
@@ -27,6 +27,7 @@ var TestResults = Backbone.Model.extend({
       passed++
     else
       failed++
+    this.get('tests').push(result)
     this.set({
       total: total,
       pending: pending,
@@ -34,7 +35,6 @@ var TestResults = Backbone.Model.extend({
       failed: failed,
       items: result.items
     })
-    this.get('tests').push(result)
   }
 })
 


### PR DESCRIPTION
I may be missing something here, but it seems to me that in [`lib/test_results.js`](https://github.com/airportyh/testem/blob/v0.8.3/lib/test_results.js#L37), you would want to push to the `tests` array before calling `set` so that by the time the split panel notices a [change](https://github.com/airportyh/testem/blob/v0.8.3/lib/dev/ui/split_log_panel.js#L84) in the results and the results display gets updated, `results.get('tests')` would have the correct length.

Currently, if you update [`getResultsDisplayText`](https://github.com/airportyh/testem/blob/v0.8.3/lib/dev/ui/split_log_panel.js#L232) to also show the length of `results.get('tests')`, the value doesn't match `results.get('total')`:

![screen shot 2015-05-31 at 12 12 39 pm](https://cloud.githubusercontent.com/assets/1691398/7902745/8a0f1d38-0791-11e5-94ea-d29368c4347d.png)

If you update the `tests` array before calling `set` on the TestResults object, however, then everything works as expected.