### PR TITLE
Allow routes as arrays for file fallback

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -276,7 +276,14 @@ Server.prototype = {
     for (var prefix in routes){
       if (uri.substring(0, prefix.length) === prefix){
         if (bestMatchLength < prefix.length){
-          bestMatch = routes[prefix] + '/' + uri.substring(prefix.length)
+          if (routes[prefix] instanceof Array) {
+            routes[prefix].some(function(folder) {
+              bestMatch = folder + '/' + uri.substring(prefix.length)
+              return fs.existsSync(bestMatch)
+            })
+          } else {
+            bestMatch = routes[prefix] + '/' + uri.substring(prefix.length)
+          }
           bestMatchLength = prefix.length
         }
       }

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -279,7 +279,7 @@ Server.prototype = {
           if (routes[prefix] instanceof Array) {
             routes[prefix].some(function(folder) {
               bestMatch = folder + '/' + uri.substring(prefix.length)
-              return fs.existsSync(bestMatch)
+              return fs.existsSync(config.resolvePath(bestMatch))
             })
           } else {
             bestMatch = routes[prefix] + '/' + uri.substring(prefix.length)

--- a/tests/server_tests.js
+++ b/tests/server_tests.js
@@ -22,6 +22,10 @@ describe('Server', function(){
           'web/hello.js',
           {src:'web/hello_tst.js', attrs: ['data-foo="true"', 'data-bar']}
         ],
+        routes: {
+          '/direct-test': 'web/direct',
+          '/fallback-test': ['web/direct', 'web/fallback']
+        },
         cwd: 'tests',
         proxies: {
           '/api1': {
@@ -124,6 +128,20 @@ describe('Server', function(){
         })
     })
 
+    describe('route', function(done) {
+      it('routes server paths to local paths', function(done) {
+        assertUrlReturnsFileContents(baseUrl + 'direct-test/test.js', 'tests/web/direct/test.js', done)
+      })
+
+      it('allows fallback paths', function(done) {
+        var expectedCallbacks = 2
+        var cb = function() {
+          if (--expectedCallbacks === 0) done()
+        }
+        assertUrlReturnsFileContents(baseUrl + 'fallback-test/test.js', 'tests/web/direct/test.js', cb)
+        assertUrlReturnsFileContents(baseUrl + 'fallback-test/test2.js', 'tests/web/fallback/test2.js', cb)
+      })
+    })
 
     describe('proxies', function() {
       var api1, api2, api3

--- a/tests/web/direct/test.js
+++ b/tests/web/direct/test.js
@@ -1,0 +1,1 @@
+console.log('test.js')

--- a/tests/web/fallback/test2.js
+++ b/tests/web/fallback/test2.js
@@ -1,0 +1,1 @@
+console.log('test2.js')


### PR DESCRIPTION
I've found this handy. Use case, for me at least, was generating instrumented JS files, but having a fallback for (e.g.) vendor libraries:

```javascript
{
  //...
  "routes": {
    "/images": "public/images",
    "/js": ["instrumented", "public/javascripts"]
  },
  //...
}
```

Didn't write any automated tests (didn't see any for the `routes` property) but used it in another project and it seems to work a treat.
