### PR TITLE
Test against iojs on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 # http://www.appveyor.com/docs/appveyor-yml
 
-# Test against these versions of Node.js.
 environment:
   matrix:
   - PHANTOM_SRC: "npm"
@@ -8,8 +7,8 @@ environment:
 
 # Install scripts. (runs after repo cloning)
 install:
-  # Get the latest stable version of Node
-  - ps: Install-Product node 0.12
+  # Get the latest stable version of io.js
+  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild 1.0)
   - npm version
   - npm install
   # Install PhantomJS


### PR DESCRIPTION
iojs ships a more recent version of npm, which causes most build
failures on Windows
node 0.10 - 0.12 are already covered on travis