### PR TITLE
add a '--type-test' argument for chrome. related to https://code.goog…

### DIFF
--- a/lib/browser_launcher.js
+++ b/lib/browser_launcher.js
@@ -94,7 +94,7 @@ function browsersForPlatform(){
           "C:\\Program Files\\Google\\Chrome\\Application\\Chrome.exe",
           "C:\\Program Files (x86)\\Google\\Chrome\\Application\\Chrome.exe"
         ],
-        args: ["--user-data-dir=" + tempDir + "\\testem.chrome", "--no-default-browser-check", "--no-first-run", "--ignore-certificate-errors"],
+        args: ["--user-data-dir=" + tempDir + "\\testem.chrome", "--no-default-browser-check", "--no-first-run", "--ignore-certificate-errors", "--test-type"],
         setup: function(config, done){
           rimraf(tempDir + '\\testem.chrome', done)
         },
@@ -136,7 +136,7 @@ function browsersForPlatform(){
           process.env.HOME + "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome",
           "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome"
         ],
-        args: ["--user-data-dir=" + tempDir + "/testem.chrome", "--no-default-browser-check", "--no-first-run", "--ignore-certificate-errors"],
+        args: ["--user-data-dir=" + tempDir + "/testem.chrome", "--no-default-browser-check", "--no-first-run", "--ignore-certificate-errors", "--test-type"],
         setup: function(config, done){
           rimraf(tempDir + '/testem.chrome', done)
         },
@@ -148,7 +148,7 @@ function browsersForPlatform(){
           process.env.HOME + "/Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary",
           "/Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary"
         ],
-        args: ["--user-data-dir=" + tempDir + "/testem.chrome-canary", "--no-default-browser-check", "--no-first-run", "--ignore-certificate-errors"],
+        args: ["--user-data-dir=" + tempDir + "/testem.chrome-canary", "--no-default-browser-check", "--no-first-run", "--ignore-certificate-errors", "--test-type"],
         setup: function(config, done){
           rimraf(tempDir + '/testem.chrome-canary', done)
         },


### PR DESCRIPTION
if chrome 40+, "--ignore-certifcate-errors" option is unsupported commnd line flag.Therefore , need to add the " --test type".

please merge this p-r.

* related info 
  * https://code.google.com/p/chromedriver/issues/detail?id=799
  * http://peter.sh/experiments/chromium-command-line-switches/#test-type

best regard. thanks :)