### PR TITLE
Preserve newlines in YAMLish of TAP reports

### DIFF
--- a/lib/ci/test_reporters/tap_reporter.js
+++ b/lib/ci/test_reporters/tap_reporter.js
@@ -30,7 +30,7 @@ TapReporter.prototype = {
         return key + ': >\n' + strutils.indent(String(err[key]))
       })
     if(logs){
-        var testLogs = ["Log: >"].concat(logs.map(function(log){return strutils.indent(String(log))}))
+        var testLogs = ["Log: |"].concat(logs.map(function(log){return strutils.indent(String(log))}))
     } else {
         var testLogs = []
     }

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -29,7 +29,7 @@ describe('test reporters', function(){
         '    ---',
         '        message: >',
         '            it crapped out',
-        '        Log: >',
+        '        Log: |',
         '            I am a log',
         '            Useful information',
         '    ...',


### PR DESCRIPTION
Use `|` instead of `>` to denote scalar content written in literal style
in "Log" diagnostics when producing TAP output.

Fixes #581.