### PR TITLE
Improving the dot reporter

### DIFF
--- a/lib/ci/test_reporters/dot_reporter.js
+++ b/lib/ci/test_reporters/dot_reporter.js
@@ -26,7 +26,11 @@ DotReporter.prototype = {
 
   display: function(prefix, result){
     if (this.silent) return
-    this.out.write('.')
+    if (result.passed) {
+      this.out.write('.')
+    } else {
+      this.out.write('F')
+    }
   },
   finish: function(){
     if (this.silent) return
@@ -37,15 +41,20 @@ DotReporter.prototype = {
     this.displayErrors()
   },
   displayErrors: function(){
-    this.results.forEach(function(result, idx){
-      result = result.result
+    this.results.forEach(function(data, idx){
+      var result = data.result
       var error = result.error
       if (!error) return
       this.out.write('  ' + (idx + 1) + ') ' + result.name + '\n')
-      if (error.stack){
-        this.out.write('     ' + error.stack)
-      }else{
-        this.out.write('     ' + error.message + '\n')
+      if (error.message) {
+        this.out.write('     message: >\n' +
+                       '       ' + error.message + '\n')
+      }
+      if ('expected' in error && 'actual' in error) {
+        this.out.write('     expected: >\n' +
+                       '       ' + error.expected + '\n')
+        this.out.write('     actual: >\n' +
+                       '       ' + error.actual + '\n')
       }
     }, this)
   },

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -61,8 +61,6 @@ describe('test reporters', function(){
       var output = stream.read().toString()
       assert.match(output, /  \./)
       assert.match(output, /1 tests complete \([0-9]+ ms\)/)
-
-      assertXmlIsValid(output)
     })
 
     it('writes out errors', function(){

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -13,16 +13,12 @@ describe('test reporters', function(){
       var reporter = new TapReporter(false, stream)
       reporter.report('phantomjs', {
         name: 'it does stuff',
-        passed: 1,
-        total: 1,
-        failed: 0,
+        passed: true,
         logs: []
       })
       reporter.report('phantomjs', {
         name: 'it fails',
-        passed: 0,
-        total: 1,
-        failed: 1,
+        passed: false,
         error: { message: 'it crapped out' },
         logs: ["I am a log", "Useful information"]
       })
@@ -53,9 +49,8 @@ describe('test reporters', function(){
       var reporter = new DotReporter(false, stream)
       reporter.report('phantomjs', {
         name: 'it does stuff',
-        passed: 1,
-        total: 1,
-        failed: 0
+        passed: true,
+        logs: []
       })
       reporter.finish()
       var output = stream.read().toString()
@@ -68,10 +63,10 @@ describe('test reporters', function(){
       var reporter = new DotReporter(false, stream)
       reporter.report('phantomjs', {
         name: 'it fails',
-        passed: 0,
-        total: 1,
-        failed: 1,
-        error: new Error('it crapped out')
+        passed: false,
+        error: {
+          message: (new Error('it crapped out')).stack
+        }
       })
       reporter.finish()
       var output = stream.read().toString()
@@ -86,9 +81,7 @@ describe('test reporters', function(){
       var reporter = new XUnitReporter(false, stream)
       reporter.report('phantomjs', {
         name: 'it does <cool> \"cool\" \'cool\' stuff',
-        passed: 1,
-        total: 1,
-        failed: 0
+        passed: true
       })
       reporter.finish()
       var output = stream.read().toString()
@@ -97,15 +90,16 @@ describe('test reporters', function(){
 
       assertXmlIsValid(output)
     })
+
     it('outputs errors', function(){
       var stream = new PassThrough()
       var reporter = new XUnitReporter(false, stream)
       reporter.report('phantomjs', {
         name: 'it didnt work',
-        passed: 0,
-        total: 1,
-        failed: 1,
-        error: new Error('it crapped out')
+        passed: false,
+        error: {
+          message: (new Error('it crapped out')).stack
+        }
       })
       reporter.finish()
       var output = stream.read().toString()
@@ -114,15 +108,16 @@ describe('test reporters', function(){
 
       assertXmlIsValid(output)
     })
+
     it('XML escapes errors', function(){
       var stream = new PassThrough()
       var reporter = new XUnitReporter(false, stream)
       reporter.report('phantomjs', {
         name: 'it failed with quotes',
-        passed: 0,
-        total: 1,
-        failed: 1,
-        error: new Error('<it> \"crapped\" out')
+        passed: false,
+        error: {
+          message: (new Error('<it> \"crapped\" out')).stack
+        }
       })
       reporter.finish()
       var output = stream.read().toString()
@@ -131,14 +126,13 @@ describe('test reporters', function(){
 
       assertXmlIsValid(output)
     })
+
     it('XML escapes messages', function(){
       var stream = new PassThrough()
       var reporter = new XUnitReporter(false, stream)
       reporter.report('phantomjs', {
         name: 'it failed with ampersands',
-        passed: 0,
-        total: 1,
-        failed: 1,
+        passed: false,
         error: { message: "&&" }
       })
       reporter.finish()
@@ -148,14 +142,13 @@ describe('test reporters', function(){
 
       assertXmlIsValid(output)
     })
+
     it('presents valid XML with null messages', function(){
       var stream = new PassThrough()
       var reporter = new XUnitReporter(false, stream)
       reporter.report('phantomjs', {
         name: 'null',
-        passed: 0,
-        total: 1,
-        failed: 1,
+        passed: false,
         error: { message: null }
       })
       reporter.finish()

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -44,7 +44,7 @@ describe('test reporters', function(){
   })
 
   describe('dot reporter', function(){
-    it('writes out result', function(){
+    it('writes out summary', function(){
       var stream = new PassThrough()
       var reporter = new DotReporter(false, stream)
       reporter.report('phantomjs', {
@@ -58,20 +58,67 @@ describe('test reporters', function(){
       assert.match(output, /1 tests complete \([0-9]+ ms\)/)
     })
 
-    it('writes out errors', function(){
+    it('writes out message and actual/expected', function(){
       var stream = new PassThrough()
       var reporter = new DotReporter(false, stream)
       reporter.report('phantomjs', {
         name: 'it fails',
         passed: false,
         error: {
-          message: (new Error('it crapped out')).stack
+          actual: 'Seven',
+          expected: 7,
+          message: 'This should be a number'
         }
       })
       reporter.finish()
       var output = stream.read().toString()
-      assert.match(output, /it fails/)
-      assert.match(output, /it crapped out/)
+      assert.match(output, /  F/)
+      assert.match(output, /1 tests complete \([0-9]+ ms\)/)
+      assert.match(output, /message: >\s+This should be a number/)
+      assert.match(output, /actual: >\s+Seven/)
+      assert.match(output, /expected: >\s+7/)
+    })
+
+    it('mutes message if there is none', function(){
+      var stream = new PassThrough()
+      var reporter = new DotReporter(false, stream)
+      reporter.report('phantomjs', {
+        name: 'it fails',
+        passed: false,
+        error: {
+          actual: 'Seven',
+          expected: 7
+        }
+      })
+      reporter.finish()
+      var output = stream.read().toString()
+      assert.notMatch(output, /message: >/)
+
+      assert.match(output, /  F/)
+      assert.match(output, /1 tests complete \([0-9]+ ms\)/)
+      assert.match(output, /actual: >\s+Seven/)
+      assert.match(output, /expected: >\s+7/)
+    })
+
+    it('mutes actual/expected if there is none', function(){
+      var stream = new PassThrough()
+      var reporter = new DotReporter(false, stream)
+      var stacktrace = (new Error('test blew up')).stack
+      reporter.report('phantomjs', {
+        name: 'it fails',
+        passed: false,
+        error: {
+          actual: null,
+          message: stacktrace
+        }
+      })
+      reporter.finish()
+      var output = stream.read().toString()
+      assert.match(output, /  F/)
+      assert.match(output, /1 tests complete \([0-9]+ ms\)/)
+      assert.match(output, /message: >\s+Error: test blew up/)
+      assert.notMatch(output, /actual: >/)
+      assert.notMatch(output, /expected: >/)
     })
   })
 


### PR DESCRIPTION
The current dot reporter does not notify errors until it is finished processing. Most dot reporters will print F's and P's for failed tests and passing tests, respectively. Additionally, the dot reporter tries to print out a message even if there is none present. Lastly, the dot reporter will now print out actual/expected in the summary.

I fixed up some of the tests to have more realistic data as well.

Tested both with npm test and by linking to my personal project with PhantomJS running QUnit.