### PR TITLE
Ignore missing launchers config option

### DIFF
--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -48,25 +48,26 @@ Common Configuration Options
 
 ### Config-level options:
 
-    launchers:              [Object]  a specification for all custom launchers
-    launch_in_dev:          [Array]   list of launchers to use for dev runs
-    launch_in_ci:           [Array]   list of launchers to use for CI runs
-    timeout:                [Number]  timeout for a browser
-    framework:              [String]  test framework to use
-    url:                    [String]  url server runs at (http://{host}:{port}/)
-    src_files:              [Array]   list of files or file patterns to use
-    src_files_ignore:       [Array]   list of files or file patterns to exclude from usage
-    serve_files:            [Array]   list of files or file patterns to inject into test playground (defaults to src_files)
-    serve_files_ignore:     [Array]   list of files or file patterns to exclude from test playground (defaults to src_files_ignore)
-    watch_files:            [Array]   list of files or file patterns to watch changes of (defaults to src_files)
-    css_files:              [Array]   additionals stylesheets to include
-    cwd:                    [Path]    directory to use as root
-    parallel:               [Number]  max number of parallel runners (1)
-    routes:                 [Object]  overrides for assets paths
-    fail_on_zero_tests:     [Boolean] whether process should exit with error status when no tests found  
-    unsafe_file_serving:    [Boolean] allow serving directories that are not in your CWD (false)
-    reporter:               [String]  name of the reporter to be used in ci mode (tap, xunit, dot)
-    disable_watching:       [Boolean] disable any file watching
+    launchers:                [Object]  a specification for all custom launchers
+    launch_in_dev:            [Array]   list of launchers to use for dev runs
+    launch_in_ci:             [Array]   list of launchers to use for CI runs
+    timeout:                  [Number]  timeout for a browser
+    framework:                [String]  test framework to use
+    url:                      [String]  url server runs at (http://{host}:{port}/)
+    src_files:                [Array]   list of files or file patterns to use
+    src_files_ignore:         [Array]   list of files or file patterns to exclude from usage
+    serve_files:              [Array]   list of files or file patterns to inject into test playground (defaults to src_files)
+    serve_files_ignore:       [Array]   list of files or file patterns to exclude from test playground (defaults to src_files_ignore)
+    watch_files:              [Array]   list of files or file patterns to watch changes of (defaults to src_files)
+    css_files:                [Array]   additionals stylesheets to include
+    cwd:                      [Path]    directory to use as root
+    parallel:                 [Number]  max number of parallel runners (1)
+    routes:                   [Object]  overrides for assets paths
+    fail_on_zero_tests:       [Boolean] whether process should exit with error status when no tests found  
+    unsafe_file_serving:      [Boolean] allow serving directories that are not in your CWD (false)
+    reporter:                 [String]  name of the reporter to be used in ci mode (tap, xunit, dot)
+    disable_watching:         [Boolean] disable any file watching
+    ignore_missing_launchers: [Boolean] ignore missing launchers in ci mode
 
 
 ### Available hooks:

--- a/lib/config.js
+++ b/lib/config.js
@@ -200,10 +200,11 @@ Config.prototype.getWantedLauncherNames = function(available){
 Config.prototype.getWantedLaunchers = function(available, cb){
   var launchers = []
   var wanted = this.getWantedLauncherNames(available)
+  var self = this
   wanted.forEach(function(name){
     var launcher = available[name.toLowerCase()]
     if (!launcher){
-      if (this.appMode === 'dev') {
+      if (self.appMode === 'dev' || self.get('ignore_missing_launchers')) {
         log.warn('Launcher "' + name + '" is not recognized.')
       }
       else {

--- a/tests/ci/ci_tests.js
+++ b/tests/ci/ci_tests.js
@@ -103,6 +103,26 @@ describe('ci mode app', function(){
     })
   })
 
+  it('passes when missing launchers are ignored', function(done){
+    var config = new Config('ci', {
+      file: 'tests/fixtures/basic_test/testem.json',
+      port: 0,
+      cwd: path.join('tests/fixtures/basic_test/'),
+      launch_in_ci: ['opera'],
+      ignore_missing_launchers: true
+    })
+    config.read(function(){
+      var app = new App(config)
+      stub(app, 'cleanExit')
+      var reporter = stub(app, 'reporter', new TestReporter(true))
+      app.start()
+      app.cleanExit.once('call', function(exitCode) {
+        expect(exitCode).to.eq(0);
+        done()
+      })
+    })
+  })
+
   it('allows passing in reporter from config', function(){
     var fakeReporter = {}
     var config = new Config('ci', {


### PR DESCRIPTION
Missing launchers should fail test runs in ci to prevent positive exits
when no launchers were found. Allow disabling this as some users rely
on a single launcher list for multiple environments

Fixes https://github.com/airportyh/testem/issues/589
