### PR TITLE
add docs for writing and configuring a custom reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ Testem has other test reporters than TAP: `dot`, `xunit` and `teamcity`. You can
 
     testem ci -R dot
 
+You can also [add your own reporter](docs/custom_reporter.md).
+
 ### Example xunit reporter output
 
 Note that the real output is not pretty printed.
@@ -196,7 +198,6 @@ Note that the real output is not pretty printed.
     ##teamcity[testFinished name='PhantomJS 1.9 - goodbye should say goodbye']
 
     ##teamcity[testSuiteFinished name='mocha.suite' duration='11091']
-
 
 ### Command line options
 

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -7,6 +7,7 @@ This document will go into more detail about the Testem configuration file and l
 * `.testem.json`
 * `testem.yml`
 * `.testem.yml`
+* `testem.js`
 
 The file is looked for in the user's current directory.
 
@@ -22,6 +23,19 @@ Here's an example `testem.json` file
             "tests/*_tests.js"
         ]
     }
+
+Here's an example `testem.js` file that defines a [custom reporter](custom_reporter.md):
+
+    var CustomReporter = require('./my-custom-reporter');
+    module.exports = {
+        "framework": "mocha",
+        "src_files": [
+            "src/*.js",
+            "tests/*_tests.js"
+        ]
+        "reporter": new CustomReporter()
+    };
+
 
 Common Configuration Options
 ----------------------------

--- a/docs/custom_reporter.md
+++ b/docs/custom_reporter.md
@@ -1,0 +1,66 @@
+Testem Custom Reporters
+=========================
+
+If the built-in reporters don't do quite what you need, you can write your own.
+This document describes how to write and configure your own custom test reporter.
+
+## Interface
+
+Your reporter should have `total` and `pass` properties, and implement `report(prefix, data)` and
+`finish()` methods.
+
+The `report` method gets called for each test with `prefix` and `data` arguments:
+* `prefix` - name of the test runner (ie PhantomJS)
+* `data` 
+    * `passed` - whether test passed
+    * `name` - test name 
+    * `error.message` - error stack
+    * `logs` - test output
+
+The `finish` method gets called when tests are complete, and can output summary information.
+
+## Example
+
+The constructor should take an (optional) output stream and initialize properties:
+
+    function MyReporter(out) {
+        this.out = out || process.stdout;
+        this.total = 0;
+        this.pass = 0;
+    }
+
+The `report` method should increment counters and output results as needed; the `finish`
+method should output summary information:
+
+    MyReporter.prototype = {
+        report: function(prefix, data) {
+            // increment counters 
+            this.total++;
+            if (data.passed) {
+                this.pass++;
+            }
+            // output results
+            var status = data.passed ? 'ok' : 'failed';
+            this.out.write(prefix+'\t'+status+'\t'+data.name.trim()+'\n');
+        },
+        finish: function() {
+            this.out.write(this.passed+'/'+this.total+' tests passed\n')
+        }
+    }
+
+## Configuration
+
+To use your custom reporter, set `reporter` in your `testem.js` config file:
+
+    var MyReporter = require('./my-reporter');
+    module.exports = {
+        "framework": "mocha",
+        "src_files": [
+            "src/*.js",
+            "tests/*_tests.js"
+        ]
+        "reporter": new MyReporter()
+    };
+
+
+


### PR DESCRIPTION
I wanted to write a custom reporter.  I found what I needed from a combination of https://github.com/airportyh/testem/issues/392 and the code for the built-in reporters.  It'd be nice if it were easier to find, so I updated the docs.

For reference, my custom reporter is https://github.com/Gridium/testem-failure-reporter