### PR TITLE
Updates README to include Sauce Connect env var

### DIFF
--- a/examples/saucelabs/README.md
+++ b/examples/saucelabs/README.md
@@ -7,7 +7,7 @@ Instructions
 ------------
 
 1. Get a [SauceLabs](https://saucelabs.com/) account.
-2. Install [saucie](https://github.com/igorlima/sauce-js-tests-integration) via `SAUCE_CONNECT_DOWNLOAD_ON_INSTALL=true sudo -E npm install saucie@0.1.0 -g`. If the SAUCE_CONNECT_DOWNLOAD_ON_INSTALL environment variable is not set then [sauce-connect-launcher will attempt to download it](https://github.com/bermi/sauce-connect-launcher#installation) on the first run which might prevent saucie from working if elevated privileges are not used.
+2. Install [saucie](https://github.com/igorlima/sauce-js-tests-integration) via `SAUCE_CONNECT_DOWNLOAD_ON_INSTALL=true sudo -E npm install saucie -g`. If the SAUCE_CONNECT_DOWNLOAD_ON_INSTALL environment variable is not set then [sauce-connect-launcher will attempt to download it](https://github.com/bermi/sauce-connect-launcher#installation) on the first run which might prevent saucie from working if elevated privileges are not used.
 3. Make sure Sauce credentials are set in env:
     * **SAUCE_USERNAME** - your SauceLabs username
     * **SAUCE_ACCESS_KEY** - your SauceLabs API/Access key.

--- a/examples/saucelabs/README.md
+++ b/examples/saucelabs/README.md
@@ -7,7 +7,7 @@ Instructions
 ------------
 
 1. Get a [SauceLabs](https://saucelabs.com/) account.
-2. Install [saucie](https://github.com/igorlima/sauce-js-tests-integration) via `npm install saucie@0.1.0 -g`.
+2. Install [saucie](https://github.com/igorlima/sauce-js-tests-integration) via `SAUCE_CONNECT_DOWNLOAD_ON_INSTALL=true sudo -E npm install saucie@0.1.0 -g`. If the SAUCE_CONNECT_DOWNLOAD_ON_INSTALL environment variable is not set then [sauce-connect-launcher will attempt to download it](https://github.com/bermi/sauce-connect-launcher#installation) on the first run which might prevent saucie from working if elevated privileges are not used.
 3. Make sure Sauce credentials are set in env:
     * **SAUCE_USERNAME** - your SauceLabs username
     * **SAUCE_ACCESS_KEY** - your SauceLabs API/Access key.

--- a/examples/saucelabs/README.md
+++ b/examples/saucelabs/README.md
@@ -7,7 +7,7 @@ Instructions
 ------------
 
 1. Get a [SauceLabs](https://saucelabs.com/) account.
-2. Install [saucie](https://github.com/igorlima/sauce-js-tests-integration) via `SAUCE_CONNECT_DOWNLOAD_ON_INSTALL=true sudo -E npm install saucie -g`. If the SAUCE_CONNECT_DOWNLOAD_ON_INSTALL environment variable is not set then [sauce-connect-launcher will attempt to download it](https://github.com/bermi/sauce-connect-launcher#installation) on the first run which might prevent saucie from working if elevated privileges are not used.
+2. Install [saucie](https://github.com/igorlima/sauce-js-tests-integration) via `SAUCE_CONNECT_DOWNLOAD_ON_INSTALL=true npm install saucie -g`. If the SAUCE_CONNECT_DOWNLOAD_ON_INSTALL environment variable is not set then [sauce-connect-launcher will attempt to download it](https://github.com/bermi/sauce-connect-launcher#installation) on the first run which might prevent saucie from working if elevated privileges are not used.
 3. Make sure Sauce credentials are set in env:
     * **SAUCE_USERNAME** - your SauceLabs username
     * **SAUCE_ACCESS_KEY** - your SauceLabs API/Access key.


### PR DESCRIPTION
saucie depends on [sauce-connect-launcher](https://github.com/bermi/sauce-connect-launcher) to create a Sauce Labs tunnel. sauce-connect-launcher [downloads and extracts a platform-specific archive](https://github.com/bermi/sauce-connect-launcher/blob/master/lib/sauce-connect-launcher.js#L119-L189). Since your Sauce Labs integration docs recommend installing saucie globally it might be worth including a note regarding this SAUCE_CONNECT_DOWNLOAD_ON_INSTALL env variable which will cause npm to execute a post-install script responsible for fetching this archive. If this isn't set then the archive needs to be downloaded when saucie is first used. If at that time saucie isn't executed using sudo then an error like the one below is encountered because the ```/usr/lib/node_modules/saucie/node_modules/sauce-connect-launcher/``` path is not writeable on Unix-like operating systems by an unprivileged account:

```
Caught exception: Error: EACCES, permission denied '/usr/lib/node_modules/saucie/node_modules/sauce-connect-launcher/sc'
    at Error (native)
    at Object.fs.mkdirSync (fs.js:747:18)
    at download (/usr/lib/node_modules/saucie/node_modules/sauce-connect-launcher/lib/sauce-connect-launcher.js:177:8)
    at /usr/lib/node_modules/saucie/node_modules/sauce-connect-launcher/node_modules/async/lib/async.js:656:23
    at fn (/usr/lib/node_modules/saucie/node_modules/sauce-connect-launcher/node_modules/async/lib/async.js:641:34)
    at Immediate._onImmediate (/usr/lib/node_modules/saucie/node_modules/sauce-connect-launcher/node_modules/async/lib/async.js:557:34)
    at processImmediate [as _immediateCallback] (timers.js:367:17)
```