### PR TITLE
socket.io v1.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "mustache": "^2.0.0",
     "npmlog": "^1.0.0",
     "rimraf": "^2.2.8",
-    "socket.io": "^1.3.4",
+    "socket.io": "^1.3.6",
     "styled_string": "0.0.1",
     "tap-parser": "^1.1.3",
     "xmldom": "^0.1.19"


### PR DESCRIPTION
Technically not a required bump, but as 1.3.6 fixes several build
issues be more explicit

Fixes https://github.com/airportyh/testem/issues/554