### PR TITLE
Fixed xunit reporter test assertion

### DIFF
--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -132,7 +132,7 @@ describe('test reporters', function(){
       })
       reporter.finish()
       var output = stream.read().toString()
-      assert.match(output, /<testsuite name="Testem Tests" tests="1" failures="0" timestamp="(.+)" time="([0-9]+)">/)
+      assert.match(output, /<testsuite name="Testem Tests" tests="1" failures="0" timestamp="(.+)" time="(\d+(\.\d+)?)">/)
       assert.match(output, /<testcase classname="phantomjs" name="it does &lt;cool> &quot;cool&quot; \'cool\' stuff"/)
 
       assertXmlIsValid(output)


### PR DESCRIPTION
time is now reported with ms, meaning it can include a `.`