### PR TITLE
Update BrowerStack configuration information

### DIFF
--- a/examples/browserstack/README.md
+++ b/examples/browserstack/README.md
@@ -8,7 +8,13 @@ Instructions
 
 1. Get a [BrowserStack](browserstack.com) account.
 2. Install [browserstack-cli](https://github.com/dbrans/browserstack-cli) via `npm install browserstack-cli -g`.
-3. Generate the browserstack configuration `browserstack setup` and enter your browserstack account information.
-4. Run the command `testem ci -l bs_chrome` to test out the setup with just the Chrome browser hosted BrowserStack.
-5. Run `testem ci` to run it on all the listed browsers - see `testem launchers` for the full list.
+3. Download the [BrowserStack binary](https://www.browserstack.com/local-testing#command-line) to some safe location on your computer, such as `~/.browserstack`
+4. Generate the browserstack configuration `browserstack setup` and enter your browserstack account information.
+5. Run the command `testem ci -l bs_chrome` to test out the setup with just the Chrome browser hosted BrowserStack.
+6. Run `testem ci` to run it on all the listed browsers - see `testem launchers` for the full list.
+
+Word of Warning
+---------------
+
+There seems to be some amount of instability when using BrowserStack with Testem together; sometimes the BrowserStack browser will disconnect as soon as the tests finish, sometimes it will happen after a delay, and sometimes it will never happen at all.  Ideally, the browser would disconnect as soon as the tests finish; the other cases, you may experience a hang after the tests complete.  Use at your own risk!
 

--- a/examples/browserstack/testem.yml
+++ b/examples/browserstack/testem.yml
@@ -1,8 +1,8 @@
 framework: jasmine
 
-on_start: 
-  command: browserstack tunnel localhost:<port>
-  wait_for_text: Tunnel is running
+on_start:
+  command: ~/.browserstack/BrowserStackLocal your_access_key
+  wait_for_text: Press Ctrl-C to exit
 
 launchers:
 


### PR DESCRIPTION
Since the initial writing of the BrowerStack documentation, things have changed and their recommendation is now to use a different program to start the tunnel to their service. I updated the docs to reflect where you can find it and how to get it working with the Testem `on_start` hook, as well as added a note about some issues that I have come across while trying to get the two to work together. Hopefully by documenting the problem, other uses will know that they aren't the only ones having it, and better yet it might spur someone at BrowserStack to look into fixing the issue.