### PR TITLE
Using custom browser id if provided

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -12,7 +12,7 @@ function Launcher(name, settings, config){
   this.config = config
   this.settings = settings
   this.setupDefaultSettings()
-  this.id = String(Math.floor(Math.random() * 10000))
+  this.id = settings.id || String(Math.floor(Math.random() * 10000))
 }
 
 Launcher.prototype = {


### PR DESCRIPTION
Currently I'm working on a wrapper for testem that will enable screenshots of the test-page (particularly useful for for ember applications). For that, the wrapper needs to launch a custom browser via selenium. Since, launching selenium browsers from testem itself is not desirable, we need to instrument the selenium browser from outside of testem. The problem with it is that there is no way to find the id that was assigned to the custom browser from outside of testem. This change addresses that, by allowing the user to specify the id to be used with the custom browser in the config file.