### PR TITLE
Show Error Messages correctly in dev

### DIFF
--- a/lib/dev/index.js
+++ b/lib/dev/index.js
@@ -75,7 +75,7 @@ function App(config, finalizer, cb){
 App.prototype = {
   __proto__: EventEmitter.prototype,
   start: function(){},
-  initView: function(){
+  initView: function() {
     var self = this
     var view = this.view
     if (this.view.on)
@@ -85,19 +85,21 @@ App.prototype = {
       self.runPostprocessors()
     })
 
+    var showError = function(titleText, err) {
+      var title = StyledString(titleText + '\n ').foreground('red')
+      var errMsgs = StyledString('\n' + err.name).foreground('white')
+        .concat(StyledString('\n' + err.message).foreground('red'))
+      view.setErrorPopupMessage(title.concat(errMsgs))
+      log.log('warn', titleText, {
+        name: err.name,
+        message: err.message
+      })
+    }
+
     self.startOnStartHook(function(err){
       if (err){
         var titleText = 'Error running on_start hook'
-        var title = StyledString(titleText + '\n ').foreground('red')
-        var errMsgs = StyledString('\n' + err.name).foreground('white')
-          .concat(StyledString('\n' + err.stdout).foreground('yellow'))
-          .concat(StyledString('\n' + err.stderr).foreground('red'))
-        view.setErrorPopupMessage(title.concat(errMsgs))
-        log.log('warn', titleText, {
-          name: err.name,
-          stdout: err.stdout,
-          stderr: err.stderr
-        })
+        showError(titleText, err)
         return
       } else {
         self.startTests(function(){
@@ -274,16 +276,7 @@ App.prototype = {
       this.runPreprocessors(function(err){
         if (err){
           var titleText = 'Error running before_tests hook'
-          var title = StyledString(titleText + '\n ').foreground('red')
-          var errMsgs = StyledString('\n' + err.name).foreground('white')
-            .concat(StyledString('\n' + err.stdout).foreground('yellow'))
-            .concat(StyledString('\n' + err.stderr).foreground('red'))
-          view.setErrorPopupMessage(title.concat(errMsgs))
-          log.log('warn', titleText, {
-            name: err.name,
-            stdout: err.stdout,
-            stderr: err.stderr
-          })
+          showError(titleText, err);
           return
         }else{
           view.clearErrorPopupMessage()

--- a/lib/dev/index.js
+++ b/lib/dev/index.js
@@ -20,6 +20,7 @@ var fireworm = require('fireworm')
 var StyledString = require('styled_string')
 var cleanExit = require('../clean_exit')
 
+
 function App(config, finalizer, cb){
   var self = this
 
@@ -75,6 +76,19 @@ function App(config, finalizer, cb){
 App.prototype = {
   __proto__: EventEmitter.prototype,
   start: function(){},
+
+  _showError: function(titleText, err) {
+    var title = StyledString(titleText + '\n ').foreground('red')
+    var errMsgs = StyledString('\n' + err.name)
+                   .foreground('white')
+                   .concat(StyledString('\n' + err.message).foreground('red'))
+    this.view.setErrorPopupMessage(title.concat(errMsgs))
+    log.log('warn', titleText, {
+      name: err.name,
+      message: err.message
+    })
+  },
+
   initView: function() {
     var self = this
     var view = this.view
@@ -85,21 +99,10 @@ App.prototype = {
       self.runPostprocessors()
     })
 
-    var showError = function(titleText, err) {
-      var title = StyledString(titleText + '\n ').foreground('red')
-      var errMsgs = StyledString('\n' + err.name).foreground('white')
-        .concat(StyledString('\n' + err.message).foreground('red'))
-      view.setErrorPopupMessage(title.concat(errMsgs))
-      log.log('warn', titleText, {
-        name: err.name,
-        message: err.message
-      })
-    }
-
     self.startOnStartHook(function(err){
       if (err){
         var titleText = 'Error running on_start hook'
-        showError(titleText, err)
+        self._showError(titleText, err)
         return
       } else {
         self.startTests(function(){
@@ -273,10 +276,11 @@ App.prototype = {
     try{
       var view = this.view
       var runners = this.runners
+      var self = this
       this.runPreprocessors(function(err){
         if (err){
           var titleText = 'Error running before_tests hook'
-          showError(titleText, err);
+          self._showError(titleText, err);
           return
         }else{
           view.clearErrorPopupMessage()


### PR DESCRIPTION
The error messages in the before_tests and onStart hooks relied on the
error object having stdout and stderr properties. Unfortunately they
don't - they use the Error object which only has a name and message
property. This meant that if one of those hooks failed the error would
say:

Error
undefined
undefined

I fixed this and removed a little duplication. There are holes here in
the testing, which I didn't fix.

See
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
for a description of the JS standard Error object.