### PR TITLE
Xunit intermediate output v2.

### DIFF
--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -77,11 +77,13 @@ Common Configuration Options
     cwd:                      [Path]    directory to use as root
     parallel:                 [Number]  max number of parallel runners (1)
     routes:                   [Object]  overrides for assets paths
-    fail_on_zero_tests:       [Boolean] whether process should exit with error status when no tests found  
+    fail_on_zero_tests:       [Boolean] whether process should exit with error status when no tests found
     unsafe_file_serving:      [Boolean] allow serving directories that are not in your CWD (false)
     reporter:                 [String]  name of the reporter to be used in ci mode (tap, xunit, dot)
     disable_watching:         [Boolean] disable any file watching
     ignore_missing_launchers: [Boolean] ignore missing launchers in ci mode
+    report_file:              [String]  file to write test results to (stdout)
+    xunit_intermediate_output [Boolean] print tap output for the xunit reporter (false)
 
 
 ### Available hooks:

--- a/lib/ci/index.js
+++ b/lib/ci/index.js
@@ -46,7 +46,12 @@ App.prototype = {
       if (!TestReporter){
         return null
       }
-      return new TestReporter(false, stream)
+      if (reporter == 'xunit') {
+        return new TestReporter(false, stream, this.config.get('xunit_intermediate_output'))
+      }
+      else {
+        return new TestReporter(false, stream)
+      }
     } else {
       return reporter
     }

--- a/lib/ci/test_reporters/tap_reporter.js
+++ b/lib/ci/test_reporters/tap_reporter.js
@@ -1,4 +1,4 @@
-var strutils = require('../../strutils')
+var displayutils = require('../../displayutils')
 
 function TapReporter(silent, out){
   this.out = out || process.stdout
@@ -21,30 +21,6 @@ TapReporter.prototype = {
     this.total++
     if (data.passed) this.pass++
   },
-  yamlDisplay: function(err, logs){
-    var failed = Object.keys(err || {})
-      .filter(function(key){
-        return key !== 'passed'
-      })
-      .map(function(key){
-        return key + ': >\n' + strutils.indent(String(err[key]))
-      })
-    if(logs){
-        var testLogs = ["Log: |"].concat(logs.map(function(log){return strutils.indent(String(log))}))
-    } else {
-        var testLogs = []
-    }
-    return strutils.indent([
-      '---',
-      strutils.indent(failed.concat(testLogs).join('\n')),
-      '...'].join('\n'))
-  },
-  resultDisplay: function(prefix, result){
-    var line = (prefix ? (prefix + ' - ') : '') +
-      result.name.trim()
-    return (result.passed ? 'ok ' : 'not ok ') +
-      (this.id++) + ' ' + line
-  },
   summaryDisplay: function(){
     var lines = [
       '1..' + this.total,
@@ -60,14 +36,7 @@ TapReporter.prototype = {
   },
   display: function(prefix, result){
     if (this.silent) return
-    this.out.write(this.resultDisplay(prefix, result) + '\n')
-    if (result.error || result.logs && result.logs.length){
-      this.out.write(this.yamlDisplay(result.error, result.logs) + '\n')
-    }
-  },
-  displayError: function(err){
-    if (this.silent) return
-    this.write('1 not ok "' + err.message.trim() + '"\n')
+    this.out.write(displayutils.resultString(this.id++, prefix, result))
   },
   finish: function(){
     if (this.silent) return

--- a/lib/ci/test_reporters/xunit_reporter.js
+++ b/lib/ci/test_reporters/xunit_reporter.js
@@ -1,9 +1,10 @@
-var strutils = require('../../strutils')
+var displayutils = require('../../displayutils')
 var XmlDom = require('xmldom')
 
 
-function XUnitReporter(silent, out){
+function XUnitReporter(silent, out, printIntermediateOutput){
   this.out = out || process.stdout
+  this.printIntermediateOutput = printIntermediateOutput
   this.silent = silent
   this.stoppedOnError = null
   this.id = 1
@@ -19,6 +20,7 @@ XUnitReporter.prototype = {
       launcher: prefix,
       result: data
     })
+    this.display(prefix, data)
     this.total++
     if (data.passed) this.pass++
   },
@@ -44,6 +46,10 @@ XUnitReporter.prototype = {
     }
 
     return new XmlDom.XMLSerializer().serializeToString(doc.documentElement);
+  },
+  display: function(prefix, result){
+    if (this.silent || !this.printIntermediateOutput || this.out == process.stdout) return
+    process.stdout.write(displayutils.resultString(this.id++, prefix, result))
   },
   getTestResultNode: function(document, result){
     var launcher = result.launcher

--- a/lib/displayutils.js
+++ b/lib/displayutils.js
@@ -1,0 +1,37 @@
+// Method to format test results.
+var strutils = require('./strutils')
+
+function resultDisplay(id, prefix, result) {
+  var line = (prefix ? (prefix + ' - ') : '') +
+    result.name.trim()
+  return (result.passed ? 'ok ' : 'not ok ') + id + ' ' + line
+}
+
+function yamlDisplay(err, logs) {
+  var failed = Object.keys(err || {})
+    .filter(function(key){
+      return key !== 'passed'
+    })
+    .map(function(key){
+      return key + ': >\n' + strutils.indent(String(err[key]))
+    })
+  if(logs){
+      var testLogs = ["Log: |"].concat(logs.map(function(log){return strutils.indent(String(log))}))
+  } else {
+      var testLogs = []
+  }
+  return strutils.indent([
+    '---',
+    strutils.indent(failed.concat(testLogs).join('\n')),
+    '...'].join('\n'))
+}
+
+function resultString(id, prefix, result) {
+  var string = resultDisplay(id, prefix, result) + '\n'
+  if (result.error || result.logs && result.logs.length){
+    string += yamlDisplay(result.error, result.logs) + '\n'
+  }
+  return string
+}
+
+exports.resultString = resultString

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -138,6 +138,42 @@ describe('test reporters', function(){
       assertXmlIsValid(output)
     })
 
+    it('uses stdout to print intermediate test results when intermediate output is enabled', function() {
+      var stream = new PassThrough()
+      var reporter = new XUnitReporter(false, stream, true)
+      var displayed = false
+      var write = process.stdout.write
+      process.stdout.write = function(string, encoding, fd) {
+        write.apply(process.stdout, [string, encoding, fd])
+        displayed = true
+      }
+      reporter.report('phantomjs', {
+        name: 'it does stuff',
+        passed: true,
+        logs: []
+      })
+      assert(displayed)
+      process.stdout.write = write
+    })
+
+    it('does not print intermediate test results when intermediate output is disabled', function() {
+      var stream = new PassThrough()
+      var reporter = new XUnitReporter(false, stream, false)
+      var displayed = false
+      var write = process.stdout.write
+      process.stdout.write = function(string, encoding, fd) {
+        write.apply(process.stdout, [string, encoding, fd])
+        displayed = true
+      }
+      reporter.report('phantomjs', {
+        name: 'it does stuff',
+        passed: true,
+        logs: []
+      })
+      assert(!displayed)
+      process.stdout.write = write
+    })
+
     it('outputs errors', function(){
       var stream = new PassThrough()
       var reporter = new XUnitReporter(false, stream)


### PR DESCRIPTION
This is similar to the previous PR, except that it will not affect any existing behavior. Adds a flag to enable xunit intermediate output (false by default). If people turn on the flag, it shows that they do indeed desire/expect intermediate output.