### PR TITLE
Fix #635

### DIFF
--- a/lib/ci/browser_test_runner.js
+++ b/lib/ci/browser_test_runner.js
@@ -6,7 +6,6 @@ function BrowserTestRunner(launcher, reporter){
   this.launcher = launcher
   this.reporter = reporter
   this.finished = false
-  this.logs = []
 }
 BrowserTestRunner.prototype = {
   start: function(onFinish){
@@ -16,16 +15,19 @@ BrowserTestRunner.prototype = {
     launcher.start()
   },
   tryAttach: function(browser, id, socket){
-    this.id = id
-    this.browserName = browser
     var self = this
     if (id == this.launcher.id){
-      socket.on('test-result', this.onTestResult.bind(this))
+      var runner = {
+        browserName: browser,
+        reporter: this.reporter,
+        logs: []
+      }
+      socket.on('test-result', this.onTestResult.bind(runner))
       socket.on('log', function(){
         for (var i = 0, l = arguments.length; i < l; i++) {
           var message = arguments[i];
 
-          this.logs.push(message);
+          runner.logs.push(message);
         }
       }.bind(this))
 
@@ -33,7 +35,7 @@ BrowserTestRunner.prototype = {
       var config = this.launcher.config
       if (config.get('bail_on_uncaught_error')){
         socket.on('top-level-error', function(msg, url, line){
-          self.reporter.report(self.browserName, {
+          self.reporter.report(browser, {
             passed: false,
             name: 'Global error: ' + msg + ' at ' + url + ', line ' + line + '\n',
             logs: [],
@@ -42,7 +44,7 @@ BrowserTestRunner.prototype = {
         })
       }
       var tap = new BrowserTapConsumer(socket)
-      tap.on('test-result', this.onTestResult.bind(this))
+      tap.on('test-result', this.onTestResult.bind(runner))
       tap.on('all-test-results', this.onAllTestResults.bind(this))
     }
   },

--- a/tests/browser_runner_tests.js
+++ b/tests/browser_runner_tests.js
@@ -5,6 +5,9 @@ var assert = require('chai').assert
 var bd = require('bodydouble')
 var stub = bd.stub
 var mock = bd.mock
+var Config = require('../lib/config')
+var Launcher = require('../lib/launcher.js')
+var BrowserTestRunner = require('../lib/ci/browser_test_runner')
 
 describe('BrowserRunner', function(){
   var socket, runner
@@ -20,6 +23,51 @@ describe('BrowserRunner', function(){
   })
   it('can create', function(){
     expect(runner.get('socket')).to.equal(socket)
+  })
+  describe('parallel runners', function(){
+    var ff = {
+      name: 'Firefox 21.0',
+      socket: new EventEmitter
+    }
+    var chrome = {
+      name: 'Chrome 19.0',
+      socket: new EventEmitter
+    }
+    var reporter = new (function() {
+      this.logsByRunner = {}
+      this.report = function(browser, msg) {
+        this.logsByRunner[browser] = this.logsByRunner[browser] || [];
+        this.logsByRunner[browser].push(msg)
+      }
+    });
+    var config = new Config('ci', {
+      parallel: 2,
+      reporter: reporter
+    });
+    var launcher = new Launcher('ci', { protocol: 'browser' }, config);
+    var runner = new BrowserTestRunner(launcher, reporter)
+
+    it('runners do not interfer with another', function(){
+      runner.tryAttach(ff.name, launcher.id, ff.socket)
+      runner.tryAttach(chrome.name, launcher.id, chrome.socket)
+
+      ff.socket.emit('test-result', {failed: 1, name: "Test1"})
+      chrome.socket.emit('test-result', {passed: true, name: "Test2"})
+
+      ff.socket.emit('all-test-results')
+      chrome.socket.emit('all-test-results')
+
+      expect(reporter.logsByRunner).to.contain.keys(ff.name, chrome.name)
+
+      expect(reporter.logsByRunner[ff.name]).to.have.length(1)
+      expect(reporter.logsByRunner[chrome.name]).to.have.length(1)
+
+      expect(reporter.logsByRunner[ff.name][0].name).to.equal("Test1")
+      expect(reporter.logsByRunner[ff.name][0].passed).to.be.false
+
+      expect(reporter.logsByRunner[chrome.name][0].name).to.equal("Test2")
+      expect(reporter.logsByRunner[chrome.name][0].passed).to.be.true
+    })
   })
   describe('reset Test Results', function(){
     it('resets topLevelError', function(){
@@ -73,4 +121,3 @@ describe('BrowserRunner', function(){
     expect(runner.get('results').get('all')).to.be.ok
   })
 })
-


### PR DESCRIPTION
This is what I'm using in our CI server to run tests in parallel and still see which browser produced each result.

What do you think?

Fixes #635 