### PR TITLE
socket.io v1.3.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "mustache": "^2.0.0",
     "npmlog": "^1.0.0",
     "rimraf": "^2.2.8",
-    "socket.io": "^1.3.6",
+    "socket.io": "^1.3.7",
     "styled_string": "0.0.1",
     "tap-parser": "^1.1.3",
     "xmldom": "^0.1.19"


### PR DESCRIPTION
Bumps ws to a version were all native deps compile using Node v4