### PR TITLE
Add query_params config

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -31,6 +31,7 @@ var fs = require('fs')
   css_files:            [Array]   additional stylesheets to include
   cwd:                  [Path]    directory to use as root
   config_dir:           [Path]    directory to use as root for resolving configs, if different than cwd
+  query_params:         [Object]  Object map defining query params to add to the test page. Can be query string also.
   parallel:             [Number]  max number of parallel runners (1)
   routes:               [Object]  overrides for assets paths
   fail_on_zero_tests:   [Boolean] whether process should exit with error status when no tests found

--- a/lib/config.js
+++ b/lib/config.js
@@ -21,11 +21,15 @@ var isa = require('./isa')
 var fileset = require('fileset')
 var fileExists = fs.exists || path.exists
 var url = require('url')
+var querystring = require('querystring');
 
 function Config(appMode, progOptions, config){
   this.appMode = appMode
   this.progOptions = progOptions || {}
   this.config = config || {}
+  this.getters = {
+    test_page:'getTestPage'
+  };
 }
 
 Config.prototype.read = function(callback){
@@ -132,7 +136,37 @@ Config.prototype.defaults = {
   reporter: 'tap'
 }
 
-Config.prototype.get = function(key){
+Config.prototype.mergeUrlAndQueryParams = function(urlString, queryParamsObj) {
+  if (typeof queryParamsObj === 'string') {
+    if (queryParamsObj[0] === '?') {
+      queryParamsObj = queryParamsObj.substr(1);
+    }
+    queryParamsObj = querystring.parse(queryParamsObj);
+  }
+
+  var urlObj = url.parse(urlString);
+  var outputQueryParams = querystring.parse(urlObj.query) || {};
+  Object.keys(queryParamsObj).forEach(function(param) {
+    outputQueryParams[param] = queryParamsObj[param];
+  });
+  urlObj.query = outputQueryParams;
+  urlObj.search = querystring.stringify(outputQueryParams);
+  urlObj.path = urlObj.pathname + urlObj.search;
+  return url.format(urlObj);
+}
+
+Config.prototype.getTestPage = function() {
+  var testPage = this.getConfigProperty('test_page');
+  var queryParams = this.getConfigProperty('query_params');
+
+  if (queryParams) {
+    return this.mergeUrlAndQueryParams(testPage, queryParams);
+  } else {
+    return testPage;
+  }
+}
+
+Config.prototype.getConfigProperty = function(key) {
   if (this.config && key in this.config) {
     return this.config[key]
   }
@@ -146,6 +180,16 @@ Config.prototype.get = function(key){
     }else{
       return defaultVal
     }
+  }
+}
+
+Config.prototype.get = function(key){
+  var getterKey = this.getters[key];
+  var getter = getterKey && this[getterKey];
+  if (getter) {
+    return getter.call(this, key);
+  } else {
+    return this.getConfigProperty(key);
   }
 }
 

--- a/tests/config_tests.js
+++ b/tests/config_tests.js
@@ -124,6 +124,67 @@ describe('Config', function(){
 		})
 	})
 
+	describe('getters system', function() {
+		it('gives precendence to getters', function(done){
+			var config = new Config('dev', {cwd: 'tests'})
+			config.getters.cwd = 'cwdGetter'
+			config.cwdGetter = function() { return 'setByGetter'; }
+			config.read(function(){
+				expect(config.get('cwd')).to.equal('setByGetter')
+				done()
+			})
+		})
+	});
+
+	describe('get test_page', function() {
+		it('defaults to config test_page', function(done){
+			var config = new Config('dev', {test_page: 'default' })
+			config.read(function(){
+				expect(config.get('test_page')).to.equal('default')
+				done()
+			})
+		})
+
+		it('adds query params if present', function(done){
+			var config = new Config('dev', {
+				test_page: 'http://my-url/path/',
+				query_params: {
+					library: 'testem',
+					language: 'javascript'
+				}
+			})
+			config.read(function(){
+				expect(config.get('test_page')).to.equal('http://my-url/path/?library=testem&language=javascript')
+				done()
+			})
+		})
+
+		it('will merge with existing params, with config params taking precedence', function(done){
+			var config = new Config('dev', {
+				test_page: 'http://my-url/path/?language=python&os=mac',
+				query_params: {
+					library: 'british',
+					language: 'english'
+				}
+			})
+			config.read(function(){
+				expect(config.get('test_page')).to.equal('http://my-url/path/?language=english&os=mac&library=british')
+				done()
+			})
+		})
+
+		it('handles string query param argument', function(done){
+			var config = new Config('dev', {
+				test_page: 'http://my-url/path/?language=python&os=mac',
+				query_params: '?language=english&library=british'
+			})
+			config.read(function(){
+				expect(config.get('test_page')).to.equal('http://my-url/path/?language=english&os=mac&library=british')
+				done()
+			})
+		})
+	});
+
 	it('give precendence to json config file', function(done){
 		var config = new Config('dev', {cwd: 'tests'})
 		config.read(function(){


### PR DESCRIPTION
Allow consumers to add query params to the test page. This allows your
config to set the test page url and a programatic API call to set the
query params.