### PR TITLE
Dot Reporter: include launcher prefix

### DIFF
--- a/lib/ci/test_reporters/dot_reporter.js
+++ b/lib/ci/test_reporters/dot_reporter.js
@@ -1,4 +1,4 @@
-var strutils = require('../../strutils')
+var printf = require('printf')
 
 function DotReporter(silent, out){
   this.out = out || process.stdout

--- a/lib/ci/test_reporters/dot_reporter.js
+++ b/lib/ci/test_reporters/dot_reporter.js
@@ -45,7 +45,7 @@ DotReporter.prototype = {
       var result = data.result
       var error = result.error
       if (!error) return
-      this.out.write('  ' + (idx + 1) + ') ' + result.name + '\n')
+      this.out.write('  ' + (idx + 1) + ') [' + data.launcher + '] ' + result.name + '\n')
       if (error.message) {
         this.out.write('     message: >\n' +
                        '       ' + error.message + '\n')

--- a/lib/ci/test_reporters/dot_reporter.js
+++ b/lib/ci/test_reporters/dot_reporter.js
@@ -45,7 +45,9 @@ DotReporter.prototype = {
       var result = data.result
       var error = result.error
       if (!error) return
-      this.out.write('  ' + (idx + 1) + ') [' + data.launcher + '] ' + result.name + '\n')
+
+      printf(this.out, '%*d) [%s] %s\n', idx+1, 3, data.launcher, result.name)
+
       if (error.message) {
         this.out.write('     message: >\n' +
                        '       ' + error.message + '\n')

--- a/lib/ci/test_reporters/dot_reporter.js
+++ b/lib/ci/test_reporters/dot_reporter.js
@@ -48,10 +48,8 @@ DotReporter.prototype = {
 
       printf(this.out, '%*d) [%s] %s\n', idx+1, 3, data.launcher, result.name)
 
-      if (error.message) {
-        this.out.write('     message: >\n' +
-                       '       ' + error.message + '\n')
-      }
+      if (error.message) printf(this.out, '     %s\n', error.message)
+
       if ('expected' in error && 'actual' in error) {
         printf(this.out, '\n' +
                '     expected: %O\n' +

--- a/lib/ci/test_reporters/dot_reporter.js
+++ b/lib/ci/test_reporters/dot_reporter.js
@@ -59,7 +59,7 @@ DotReporter.prototype = {
     }, this)
   },
   summaryDisplay: function(){
-    return '  ' + this.total + ' tests complete (' + this.duration() + ' ms)'
+    return printf('  %d tests complete (%d ms)', this.total, this.duration())
   },
   duration: function(){
     return Math.round((this.endTime - this.startTime))

--- a/lib/ci/test_reporters/dot_reporter.js
+++ b/lib/ci/test_reporters/dot_reporter.js
@@ -53,11 +53,11 @@ DotReporter.prototype = {
                        '       ' + error.message + '\n')
       }
       if ('expected' in error && 'actual' in error) {
-        this.out.write('     expected: >\n' +
-                       '       ' + error.expected + '\n')
-        this.out.write('     actual: >\n' +
-                       '       ' + error.actual + '\n')
+        printf(this.out, '\n' +
+               '     expected: %O\n' +
+               '       actual: %O\n', error.expected, error.actual)
       }
+      this.out.write('\n')
     }, this)
   },
   summaryDisplay: function(){

--- a/lib/ci/test_reporters/dot_reporter.js
+++ b/lib/ci/test_reporters/dot_reporter.js
@@ -1,3 +1,4 @@
+var indent = require('../../strutils').indent
 var printf = require('printf')
 
 function DotReporter(silent, out){
@@ -55,6 +56,9 @@ DotReporter.prototype = {
                '     expected: %O\n' +
                '       actual: %O\n', error.expected, error.actual)
       }
+
+      if (error.stack) printf(this.out, '\n%s', indent(error.stack, 5))
+
       this.out.write('\n')
     }, this)
   },

--- a/lib/strutils.js
+++ b/lib/strutils.js
@@ -6,9 +6,9 @@ function pad(str, l, s, t){
     + str + s.substr(0, l - t) : str).substring(0, ol)
 }
 
-function indent(text){
+function indent(text, width){
   return text.split('\n').map(function(line){
-    return '    ' + line
+    return Array((width||4) + 1).join(' ') + line
   }).join('\n')
 }
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "mkdirp": "^0.5.0",
     "mustache": "^2.0.0",
     "npmlog": "^1.0.0",
+    "printf": "^0.2.3",
     "rimraf": "^2.2.8",
     "socket.io": "^1.3.7",
     "styled_string": "0.0.1",

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -70,7 +70,8 @@ describe('test reporters', function(){
           error: {
             actual: 'Seven',
             expected: 7,
-            message: 'This should be a number'
+            message: 'This should be a number',
+            stack: 'trace'
           }
         })
         reporter.finish()
@@ -87,6 +88,7 @@ describe('test reporters', function(){
         assert.match(output.shift(), /     expected: 7/)
         assert.match(output.shift(), /       actual: 'Seven'/)
         output.shift()
+        assert.match(output.shift(), /     trace/)
         assert.equal(output, '')
       })
     })

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -44,81 +44,51 @@ describe('test reporters', function(){
   })
 
   describe('dot reporter', function(){
-    it('writes out summary', function(){
-      var stream = new PassThrough()
-      var reporter = new DotReporter(false, stream)
-      reporter.report('phantomjs', {
-        name: 'it does stuff',
-        passed: true,
-        logs: []
+    context('without errors', function(){
+      it('writes out summary', function(){
+        var stream = new PassThrough()
+        var reporter = new DotReporter(false, stream)
+        reporter.report('phantomjs', {
+          name: 'it does stuff',
+          passed: true,
+          logs: []
+        })
+        reporter.finish()
+        var output = stream.read().toString()
+        assert.match(output, /  \./)
+        assert.match(output, /1 tests complete \([0-9]+ ms\)/)
       })
-      reporter.finish()
-      var output = stream.read().toString()
-      assert.match(output, /  \./)
-      assert.match(output, /1 tests complete \([0-9]+ ms\)/)
     })
 
-    it('writes out message and actual/expected', function(){
-      var stream = new PassThrough()
-      var reporter = new DotReporter(false, stream)
-      reporter.report('phantomjs', {
-        name: 'it fails',
-        passed: false,
-        error: {
-          actual: 'Seven',
-          expected: 7,
-          message: 'This should be a number'
-        }
-      })
-      reporter.finish()
-      var output = stream.read().toString()
-      assert.match(output, /  F/)
-      assert.match(output, /1 tests complete \([0-9]+ ms\)/)
-      assert.match(output, /message: >\s+This should be a number/)
-      assert.match(output, /actual: 'Seven'/)
-      assert.match(output, /expected: 7/)
-    })
+    context('with errors', function(){
+      it('writes out summary with failure info', function(){
+        var stream = new PassThrough()
+        var reporter = new DotReporter(false, stream)
+        reporter.report('phantomjs', {
+          name: 'it fails',
+          passed: false,
+          error: {
+            actual: 'Seven',
+            expected: 7,
+            message: 'This should be a number'
+          }
+        })
+        reporter.finish()
+        var output = stream.read().toString().split('\n')
 
-    it('mutes message if there is none', function(){
-      var stream = new PassThrough()
-      var reporter = new DotReporter(false, stream)
-      reporter.report('phantomjs', {
-        name: 'it fails',
-        passed: false,
-        error: {
-          actual: 'Seven',
-          expected: 7
-        }
+        output.shift()
+        assert.match(output.shift(), /  F/)
+        output.shift()
+        assert.match(output.shift(), /  1 tests complete \(\d+ ms\)/)
+        output.shift()
+        assert.match(output.shift(), /  1\) \[phantomjs\] it fails/)
+        assert.match(output.shift(), /     This should be a number/)
+        output.shift()
+        assert.match(output.shift(), /     expected: 7/)
+        assert.match(output.shift(), /       actual: 'Seven'/)
+        output.shift()
+        assert.equal(output, '')
       })
-      reporter.finish()
-      var output = stream.read().toString()
-      assert.notMatch(output, /message: >/)
-
-      assert.match(output, /  F/)
-      assert.match(output, /1 tests complete \([0-9]+ ms\)/)
-      assert.match(output, /actual: 'Seven'/)
-      assert.match(output, /expected: 7/)
-    })
-
-    it('mutes actual/expected if there is none', function(){
-      var stream = new PassThrough()
-      var reporter = new DotReporter(false, stream)
-      var stacktrace = (new Error('test blew up')).stack
-      reporter.report('phantomjs', {
-        name: 'it fails',
-        passed: false,
-        error: {
-          actual: null,
-          message: stacktrace
-        }
-      })
-      reporter.finish()
-      var output = stream.read().toString()
-      assert.match(output, /  F/)
-      assert.match(output, /1 tests complete \([0-9]+ ms\)/)
-      assert.match(output, /message: >\s+Error: test blew up/)
-      assert.notMatch(output, /actual: /)
-      assert.notMatch(output, /expected: /)
     })
   })
 

--- a/tests/ci/reporter_tests.js
+++ b/tests/ci/reporter_tests.js
@@ -75,8 +75,8 @@ describe('test reporters', function(){
       assert.match(output, /  F/)
       assert.match(output, /1 tests complete \([0-9]+ ms\)/)
       assert.match(output, /message: >\s+This should be a number/)
-      assert.match(output, /actual: >\s+Seven/)
-      assert.match(output, /expected: >\s+7/)
+      assert.match(output, /actual: 'Seven'/)
+      assert.match(output, /expected: 7/)
     })
 
     it('mutes message if there is none', function(){
@@ -96,8 +96,8 @@ describe('test reporters', function(){
 
       assert.match(output, /  F/)
       assert.match(output, /1 tests complete \([0-9]+ ms\)/)
-      assert.match(output, /actual: >\s+Seven/)
-      assert.match(output, /expected: >\s+7/)
+      assert.match(output, /actual: 'Seven'/)
+      assert.match(output, /expected: 7/)
     })
 
     it('mutes actual/expected if there is none', function(){
@@ -117,8 +117,8 @@ describe('test reporters', function(){
       assert.match(output, /  F/)
       assert.match(output, /1 tests complete \([0-9]+ ms\)/)
       assert.match(output, /message: >\s+Error: test blew up/)
-      assert.notMatch(output, /actual: >/)
-      assert.notMatch(output, /expected: >/)
+      assert.notMatch(output, /actual: /)
+      assert.notMatch(output, /expected: /)
     })
   })
 


### PR DESCRIPTION
- Include the launcher prefix in the error listing from the DOT reporter.
- Restore stacktrace to error output
- Use standard printf format strings and less string concatenation
- Restructure error output to follow prior art (mocha, rspec, etc)
- Eliminate redundant tests (no real value added)