### PR TITLE
Add PhantomJS for FreeBSD

### DIFF
--- a/lib/browser_launcher.js
+++ b/lib/browser_launcher.js
@@ -253,6 +253,15 @@ function browsersForPlatform(){
           supported: findableByWhichOrModule
         }
   	]
+  }else if (platform === 'freebsd') {
+  	return [
+        {
+          name: 'PhantomJS',
+          exe: 'phantomjs',
+          args: buildPhantomJsArgs,
+          supported: findableByWhichOrModule
+        }
+  	]
   }else{
     return []
   }


### PR DESCRIPTION
Hi there,

I'm one of the few folks whose development environment is FreeBSD 10, which makes running Ember-CLI tests through testem difficult because testem has no launchers for FreeBSD.

This commit adds PhantomJS as a default launcher for FreeBSD. I've tested this through Ember-CLI v1.13.8 and FreeBSD 10.2 with the ports package for PhantomJS 2.0.0 and it seems to work just fine.

Let me know if more is needed for this

Thanks!