### PR TITLE
Remove native optional dependencies from socket.io

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "npmlog": "^1.0.0",
     "printf": "^0.2.3",
     "rimraf": "^2.2.8",
-    "socket.io": "^1.3.7",
+    "socket.io": "patocallaghan/socket.io#1.3.7-pure",
     "styled_string": "0.0.1",
     "tap-parser": "^1.1.3",
     "xmldom": "^0.1.19"


### PR DESCRIPTION
As discussed in https://github.com/ember-cli/ember-cli/pull/5036#issuecomment-154489240 with @johanneswuerbach and @stefanpenner

This PR removes the dependence on the native libs `bufferutil` and `utf-8` installed with `socket.io`. To do this I've forked the repo tree and made the changes required. This removes the need to install `testem` or `ember-cli` with the `--no-optional` flag to opt out of the native libs.

-- socket.io@1.3.7 - [diff](https://github.com/socketio/socket.io/compare/e2ebd43...patocallaghan:1.3.7-pure)
&nbsp;&nbsp;&nbsp;&nbsp;-- engine.io@1.5.4 - [diff](https://github.com/socketio/engine.io/compare/6032a13...patocallaghan:1.5.4-pure)
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-- ws@0.8.0 - [diff](https://github.com/websockets/ws/compare/0.8.0...patocallaghan:0.8.0-pure)
&nbsp;&nbsp;&nbsp;&nbsp;-- socket.io-client@1.3.7 - [diff](https://github.com/socketio/socket.io-client/compare/3fe5c2a...patocallaghan:1.3.7-pure)