### PR TITLE
Use published socket.io without native dependencies

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -9,7 +9,7 @@ running the tests in a browser.
 */
 
 var express = require('express')
-var socketIO = require('socket.io')
+var socketIO = require('socket.io-pure')
 var fs = require('fs')
 var path = require('path')
 var async = require('async')

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "npmlog": "^1.0.0",
     "printf": "^0.2.3",
     "rimraf": "^2.2.8",
-    "socket.io": "patocallaghan/socket.io#1.3.7-pure",
+    "socket.io-pure": "^1.3.11",
     "styled_string": "0.0.1",
     "tap-parser": "^1.1.3",
     "xmldom": "^0.1.19"


### PR DESCRIPTION
Fixes https://github.com/airportyh/testem/issues/659, fixes https://github.com/airportyh/testem/issues/660